### PR TITLE
Switched to GCC6 with LibNix for Amiga, disabled the timidity, mp3 and vorbis codecs

### DIFF
--- a/common/net_sys.h
+++ b/common/net_sys.h
@@ -145,6 +145,8 @@ COMPILE_TIME_ASSERT(sockaddr, offsetof(struct sockaddr, sa_family) == SA_FAM_OFF
 
 #ifndef PLATFORM_AMIGAOS3
 #include <sys/param.h>
+#else
+#define __NO_NET_API
 #endif
 #include <sys/ioctl.h>
 #ifdef PLATFORM_AMIGAOS3

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -983,7 +983,10 @@ ifeq ($(TARGET_OS),amigaos)
 BEBBO_TOOLCHAIN=yes
 
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 
 # Don't use SDL on AmigaOS
 USE_SDL=no
@@ -995,7 +998,6 @@ USE_CDAUDIO=no
 endif
 
 ifndef DEBUG
-#CFLAGS  += -O3
 ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
@@ -1022,8 +1024,8 @@ endif
 
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
-# AmiTCP SDK
 ifneq ($(BEBBO_TOOLCHAIN),yes)
+# Roadshow SDK
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
 endif
 

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -980,7 +980,7 @@ endif
 ifeq ($(TARGET_OS),amigaos)
 
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 
 # Don't use SDL on AmigaOS
 USE_SDL=no
@@ -992,9 +992,11 @@ USE_CDAUDIO=no
 endif
 
 ifndef DEBUG
-CFLAGS  += -O3
+#CFLAGS  += -O3
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
-CFLAGS  += -fno-omit-frame-pointer
+#CFLAGS  += -fno-omit-frame-pointer
+# these break the game with GCC6
+CFLAGS  += -fbbb=- -fno-tree-forwprop
 endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
@@ -1015,7 +1017,7 @@ endif
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
 # AmiTCP SDK
-NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+#NET_INC   = -I$(OSLIBS)/amigaos/netinclude
 
 # Build for which Amiga GL implementation:
 # Either amesa (StormMesa), or minigl (Hyperion's MiniGL 1.2)
@@ -1034,7 +1036,10 @@ endif
 # dynamic loading of ogl functions doesn't work
 LINK_GL_LIBS=yes
 
+USE_CODEC_TIMIDITY=no
 USE_CODEC_FLAC=no
+USE_CODEC_MP3=no
+USE_CODEC_VORBIS=no
 USE_CODEC_OPUS=no
 USE_CODEC_MIKMOD=no
 USE_CODEC_UMX=no

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -979,6 +979,9 @@ endif
 #############################################################
 ifeq ($(TARGET_OS),amigaos)
 
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
+
 # crt: libnix or clib2:
 USE_CLIB2=no
 
@@ -993,10 +996,13 @@ endif
 
 ifndef DEBUG
 #CFLAGS  += -O3
+ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
-#CFLAGS  += -fno-omit-frame-pointer
+CFLAGS  += -fno-omit-frame-pointer
+else
 # these break the game with GCC6
 CFLAGS  += -fbbb=- -fno-tree-forwprop
+endif
 endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
@@ -1017,7 +1023,9 @@ endif
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
 # AmiTCP SDK
-#NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+ifneq ($(BEBBO_TOOLCHAIN),yes)
+NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+endif
 
 # Build for which Amiga GL implementation:
 # Either amesa (StormMesa), or minigl (Hyperion's MiniGL 1.2)

--- a/engine/hexen2/server/Makefile
+++ b/engine/hexen2/server/Makefile
@@ -271,7 +271,7 @@ endif
 ifeq ($(TARGET_OS),amigaos)
 
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 
 ifndef DEBUG
 CFLAGS  += -O3

--- a/engine/hexen2/server/Makefile
+++ b/engine/hexen2/server/Makefile
@@ -270,13 +270,23 @@ endif
 #############################################################
 ifeq ($(TARGET_OS),amigaos)
 
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
+
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 
 ifndef DEBUG
-CFLAGS  += -O3
+ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
+else
+# these break the game with GCC6
+CFLAGS  += -fbbb=- -fno-tree-forwprop
+endif
 endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
@@ -289,8 +299,10 @@ SYSLIBS += -lm
 
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
-# AmiTCP SDK
+ifneq ($(BEBBO_TOOLCHAIN),yes)
+# Roadshow SDK
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+endif
 
 endif
 # End of AmigaOS settings

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -944,7 +944,10 @@ ifeq ($(TARGET_OS),amigaos)
 BEBBO_TOOLCHAIN=yes
 
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 
 # Don't use SDL on AmigaOS
 USE_SDL=no
@@ -956,7 +959,6 @@ USE_CDAUDIO=no
 endif
 
 ifndef DEBUG
-#CFLAGS  += -O3
 ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
@@ -983,8 +985,8 @@ endif
 
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
-# AmiTCP SDK
 ifneq ($(BEBBO_TOOLCHAIN),yes)
+# Roadshow SDK
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
 endif
 

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -940,6 +940,9 @@ endif
 #############################################################
 ifeq ($(TARGET_OS),amigaos)
 
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
+
 # crt: libnix or clib2:
 USE_CLIB2=no
 
@@ -953,9 +956,14 @@ USE_CDAUDIO=no
 endif
 
 ifndef DEBUG
-CFLAGS  += -O3
+#CFLAGS  += -O3
+ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
+else
+# these break the game with GCC6
+CFLAGS  += -fbbb=- -fno-tree-forwprop
+endif
 endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
@@ -976,7 +984,9 @@ endif
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
 # AmiTCP SDK
+ifneq ($(BEBBO_TOOLCHAIN),yes)
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+endif
 
 # Build for which Amiga GL implementation:
 # Either amesa (StormMesa), or minigl (Hyperion's MiniGL 1.2)
@@ -995,7 +1005,10 @@ endif
 # dynamic loading of ogl functions doesn't work
 LINK_GL_LIBS=yes
 
+USE_CODEC_TIMIDITY=no
 USE_CODEC_FLAC=no
+USE_CODEC_MP3=no
+USE_CODEC_VORBIS=no
 USE_CODEC_OPUS=no
 USE_CODEC_MIKMOD=no
 USE_CODEC_UMX=no

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -941,7 +941,7 @@ endif
 ifeq ($(TARGET_OS),amigaos)
 
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 
 # Don't use SDL on AmigaOS
 USE_SDL=no

--- a/engine/hexenworld/server/Makefile
+++ b/engine/hexenworld/server/Makefile
@@ -263,13 +263,21 @@ endif
 #############################################################
 ifeq ($(TARGET_OS),amigaos)
 
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
+
 # crt: libnix or clib2:
 USE_CLIB2=no
 
 ifndef DEBUG
-CFLAGS  += -O3
+#CFLAGS  += -O3
+ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
+else
+# these break the game with GCC6
+CFLAGS  += -fbbb=- -fno-tree-forwprop
+endif
 endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
@@ -283,7 +291,9 @@ SYSLIBS += -lm
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
 # AmiTCP SDK
+ifneq ($(BEBBO_TOOLCHAIN),yes)
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+endif
 
 endif
 # End of AmigaOS settings

--- a/engine/hexenworld/server/Makefile
+++ b/engine/hexenworld/server/Makefile
@@ -267,10 +267,12 @@ ifeq ($(TARGET_OS),amigaos)
 BEBBO_TOOLCHAIN=yes
 
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 
 ifndef DEBUG
-#CFLAGS  += -O3
 ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
@@ -290,8 +292,8 @@ SYSLIBS += -lm
 
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
-# AmiTCP SDK
 ifneq ($(BEBBO_TOOLCHAIN),yes)
+# Roadshow SDK
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
 endif
 

--- a/engine/hexenworld/server/Makefile
+++ b/engine/hexenworld/server/Makefile
@@ -264,7 +264,7 @@ endif
 ifeq ($(TARGET_OS),amigaos)
 
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 
 ifndef DEBUG
 CFLAGS  += -O3

--- a/h2patch/Makefile.amiga
+++ b/h2patch/Makefile.amiga
@@ -29,8 +29,13 @@ endif
 NOIXEMUL= 1
 
 ifeq ($(AOS3),1)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 NOIXEMUL= 0
 CFLAGS += -mcrt=clib2

--- a/h2patch/Makefile.amiga
+++ b/h2patch/Makefile.amiga
@@ -30,7 +30,7 @@ NOIXEMUL= 1
 
 ifeq ($(AOS3),1)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 NOIXEMUL= 0
 CFLAGS += -mcrt=clib2

--- a/hw_utils/hwmaster/Makefile
+++ b/hw_utils/hwmaster/Makefile
@@ -133,8 +133,13 @@ LDFLAGS += -noixemul
 endif
 
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -147,8 +152,10 @@ CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
-# AmiTCP SDK
+ifneq ($(BEBBO_TOOLCHAIN),yes)
+# Roadshow SDK
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+endif
 endif
 
 

--- a/hw_utils/hwmaster/Makefile
+++ b/hw_utils/hwmaster/Makefile
@@ -134,7 +134,7 @@ endif
 
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/hw_utils/hwmquery/Makefile
+++ b/hw_utils/hwmquery/Makefile
@@ -133,8 +133,13 @@ LDFLAGS += -noixemul
 endif
 
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -147,8 +152,10 @@ CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
-# AmiTCP SDK
+ifneq ($(BEBBO_TOOLCHAIN),yes)
+# Roadshow SDK
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+endif
 endif
 
 

--- a/hw_utils/hwmquery/Makefile
+++ b/hw_utils/hwmquery/Makefile
@@ -134,7 +134,7 @@ endif
 
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/hw_utils/hwrcon/Makefile
+++ b/hw_utils/hwrcon/Makefile
@@ -135,7 +135,7 @@ endif
 
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/hw_utils/hwrcon/Makefile
+++ b/hw_utils/hwrcon/Makefile
@@ -134,8 +134,13 @@ LDFLAGS += -noixemul
 endif
 
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -148,8 +153,10 @@ CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers
 INCLUDES += -I$(OSLIBS)/amigaos/include
-# AmiTCP SDK
+ifneq ($(BEBBO_TOOLCHAIN),yes)
+# Roadshow SDK
 NET_INC   = -I$(OSLIBS)/amigaos/netinclude
+endif
 endif
 
 

--- a/libs/timidity/Makefile
+++ b/libs/timidity/Makefile
@@ -79,7 +79,7 @@ endif
 
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/libs/timidity/Makefile
+++ b/libs/timidity/Makefile
@@ -78,8 +78,13 @@ ifeq ($(TARGET_OS),aros)
 endif
 
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -88,7 +93,6 @@ endif
 
 CFLAGS += $(CRT_FLAGS) -m68060 -m68881
 ifndef DEBUG
-CFLAGS += -O3
 CFLAGS += -fno-omit-frame-pointer
 endif
 # for extra missing headers

--- a/oslibs/amigaos/include/stdint.h
+++ b/oslibs/amigaos/include/stdint.h
@@ -1,4 +1,4 @@
-#ifdef __CLIB2__
+#if defined(__CLIB2__) || defined(__libnix__)
 #include_next <stdint.h> /* clib2 provides a stdint.h already */
 
 #else

--- a/oslibs/amigaos/include/stdint.h
+++ b/oslibs/amigaos/include/stdint.h
@@ -1,4 +1,4 @@
-#if defined(__CLIB2__) || defined(__libnix__)
+#ifdef __CLIB2__
 #include_next <stdint.h> /* clib2 provides a stdint.h already */
 
 #else
@@ -72,12 +72,18 @@ typedef u_int64_t uint_fast64_t;
 #define UINT_FAST64_MAX ULLONG_MAX
 
 
+#ifndef _INTPTR_T_DECLARED
 typedef long intptr_t;
 #define INTPTR_MIN LONG_MIN
 #define INTPTR_MAX LONG_MAX
+#define _INTPTR_T_DECLARED
+#endif
 
+#ifndef _UINTPTR_T_DECLARED
 typedef unsigned long uintptr_t;
 #define UINTPTR_MAX ULONG_MAX
+#define _UINTPTR_T_DECLARED
+#endif
 
 typedef long long intmax_t;
 #define INTMAX_MIN LLONG_MIN

--- a/scripts/cross_defs.amigaos
+++ b/scripts/cross_defs.amigaos
@@ -4,7 +4,7 @@
 # Change this script to meet your needs and/or environment.
 
 TARGET=m68k-amigaos
-PREFIX=/opt/m68k-amigaos
+PREFIX=/opt/amiga
 
 PATH="$PREFIX/bin:$PATH"
 export PATH

--- a/scripts/cross_defs.amigaos
+++ b/scripts/cross_defs.amigaos
@@ -4,7 +4,8 @@
 # Change this script to meet your needs and/or environment.
 
 TARGET=m68k-amigaos
-PREFIX=/opt/amiga
+#PREFIX=/opt/amiga
+PREFIX=/opt/m68k-amigaos
 
 PATH="$PREFIX/bin:$PATH"
 export PATH

--- a/utils/bsp2map/Makefile
+++ b/utils/bsp2map/Makefile
@@ -85,8 +85,13 @@ LDFLAGS += -noixemul
 LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/bsp2map/Makefile
+++ b/utils/bsp2map/Makefile
@@ -86,7 +86,7 @@ LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/bspinfo/Makefile
+++ b/utils/bspinfo/Makefile
@@ -84,8 +84,13 @@ CFLAGS  += -noixemul
 LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/bspinfo/Makefile
+++ b/utils/bspinfo/Makefile
@@ -85,7 +85,7 @@ LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/dcc/Makefile
+++ b/utils/dcc/Makefile
@@ -84,8 +84,13 @@ CFLAGS  += -noixemul
 LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/dcc/Makefile
+++ b/utils/dcc/Makefile
@@ -85,7 +85,7 @@ LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/genmodel/Makefile
+++ b/utils/genmodel/Makefile
@@ -87,7 +87,7 @@ LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/genmodel/Makefile
+++ b/utils/genmodel/Makefile
@@ -86,8 +86,13 @@ LDFLAGS += -noixemul
 LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -97,7 +102,6 @@ CFLAGS  += $(CRT_FLAGS) -m68060 -m68881
 LDFLAGS += $(CRT_FLAGS) -m68060 -m68881
 LDLIBS  += -lm
 ifndef DEBUG
-CFLAGS  += -O3
 CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers

--- a/utils/hcc/Makefile
+++ b/utils/hcc/Makefile
@@ -84,8 +84,13 @@ CFLAGS  += -noixemul
 LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/hcc/Makefile
+++ b/utils/hcc/Makefile
@@ -85,7 +85,7 @@ LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/jsh2color/Makefile
+++ b/utils/jsh2color/Makefile
@@ -91,8 +91,13 @@ LDFLAGS += -noixemul
 LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -102,7 +107,6 @@ CFLAGS  += $(CRT_FLAGS) -m68060 -m68881
 LDFLAGS += $(CRT_FLAGS) -m68060 -m68881
 LDLIBS  += -lm
 ifndef DEBUG
-CFLAGS  += -O3
 CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers

--- a/utils/jsh2color/Makefile
+++ b/utils/jsh2color/Makefile
@@ -92,7 +92,7 @@ LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/light/Makefile
+++ b/utils/light/Makefile
@@ -88,7 +88,7 @@ LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/light/Makefile
+++ b/utils/light/Makefile
@@ -87,8 +87,13 @@ LDFLAGS += -noixemul
 LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -98,7 +103,6 @@ CFLAGS  += $(CRT_FLAGS) -m68060 -m68881
 LDFLAGS += $(CRT_FLAGS) -m68060 -m68881
 LDLIBS  += -lm
 ifndef DEBUG
-CFLAGS  += -O3
 CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers

--- a/utils/pak/Makefile
+++ b/utils/pak/Makefile
@@ -85,8 +85,13 @@ CFLAGS  += -noixemul
 LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/pak/Makefile
+++ b/utils/pak/Makefile
@@ -86,7 +86,7 @@ LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/qbsp/Makefile
+++ b/utils/qbsp/Makefile
@@ -88,7 +88,7 @@ LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/qbsp/Makefile
+++ b/utils/qbsp/Makefile
@@ -87,8 +87,13 @@ LDFLAGS += -noixemul
 LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -98,7 +103,6 @@ CFLAGS  += $(CRT_FLAGS) -m68060 -m68881
 LDFLAGS += $(CRT_FLAGS) -m68060 -m68881
 LDLIBS  += -lm
 ifndef DEBUG
-CFLAGS  += -O3
 CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers

--- a/utils/qfiles/Makefile
+++ b/utils/qfiles/Makefile
@@ -84,8 +84,13 @@ CFLAGS  += -noixemul
 LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/qfiles/Makefile
+++ b/utils/qfiles/Makefile
@@ -85,7 +85,7 @@ LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/texutils/bsp2wal/Makefile
+++ b/utils/texutils/bsp2wal/Makefile
@@ -84,8 +84,13 @@ CFLAGS  += -noixemul
 LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/texutils/bsp2wal/Makefile
+++ b/utils/texutils/bsp2wal/Makefile
@@ -85,7 +85,7 @@ LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/texutils/lmp2pcx/Makefile
+++ b/utils/texutils/lmp2pcx/Makefile
@@ -84,8 +84,13 @@ CFLAGS  += -noixemul
 LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/texutils/lmp2pcx/Makefile
+++ b/utils/texutils/lmp2pcx/Makefile
@@ -85,7 +85,7 @@ LDFLAGS += -noixemul
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/vis/Makefile
+++ b/utils/vis/Makefile
@@ -88,7 +88,7 @@ LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
 # crt: libnix or clib2:
-USE_CLIB2=yes
+USE_CLIB2=no
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else

--- a/utils/vis/Makefile
+++ b/utils/vis/Makefile
@@ -87,8 +87,13 @@ LDFLAGS += -noixemul
 LDLIBS  += -lm
 endif
 ifeq ($(TARGET_OS),amigaos)
+# use Bebbo's GCC6 toolchain
+BEBBO_TOOLCHAIN=yes
 # crt: libnix or clib2:
+USE_CLIB2=yes
+ifeq ($(BEBBO_TOOLCHAIN),yes)
 USE_CLIB2=no
+endif
 ifeq ($(USE_CLIB2),yes)
 CRT_FLAGS=-mcrt=clib2
 else
@@ -98,7 +103,6 @@ CFLAGS  += $(CRT_FLAGS) -m68060 -m68881
 LDFLAGS += $(CRT_FLAGS) -m68060 -m68881
 LDLIBS  += -lm
 ifndef DEBUG
-CFLAGS  += -O3
 CFLAGS  += -fno-omit-frame-pointer
 endif
 # for extra missing headers


### PR DESCRIPTION
I started working on the AmigaOS3.x port of uhexen2 again to make it playable on 68060 accelerators. As a first step I fixed the game to properly build with Bebbo's GCC6 toolchain which produces faster code:
https://github.com/bebbo/amiga-gcc
I also switched back to LibNix as the one comes with that toolchain is actively maintained and fixes many of the original bugs. The Vorbis, MP3 and Timidity codecs are disabled for now, as these are too slow on the real hardware. I plan to restore MP3 support later using MHI which uses hardware decoders on sounds cards and external decoders like the MAS Player.
Let me know if I missed something or there's something else I should change in the PR.