### PR TITLE
Amiga code cleanup

### DIFF
--- a/engine/h2shared/in_amiga.c
+++ b/engine/h2shared/in_amiga.c
@@ -288,14 +288,14 @@ static struct EmulLibEntry IN_KeyboardHandler =
 static struct InputEvent *IN_KeyboardHandlerFunc()
 {
 	struct InputEvent *moo = (struct InputEvent *)REG_A0;
-	struct inputdata *id = (struct inputdata *)REG_A1;
+	//struct inputdata *id = (struct inputdata *)REG_A1;
 #else
 HANDLERPROTO(IN_KeyboardHandler, struct InputEvent *, struct InputEvent *moo, APTR id)
 {
 #endif
 	struct InputEvent *coin;
 
-	qboolean screeninfront, handlemouse;
+	ULONG screeninfront, handlemouse;
 
 	if (!window || !(window->Flags & WFLG_WINDOWACTIVE))
 		return moo;
@@ -310,7 +310,7 @@ HANDLERPROTO(IN_KeyboardHandler, struct InputEvent *, struct InputEvent *moo, AP
 			screeninfront = (window->WScreen == IntuitionBase->FirstScreen);
 	}
 	else
-		screeninfront = true;
+		screeninfront = 1;
 
 	handlemouse = screeninfront && mouseactive;
 

--- a/engine/h2shared/vid_cgx.c
+++ b/engine/h2shared/vid_cgx.c
@@ -27,6 +27,7 @@
 #include <intuition/intuitionbase.h>
 #include <cybergraphx/cybergraphics.h>
 #include <exec/execbase.h>
+#include <graphics/videocontrol.h>
 
 #include <proto/exec.h>
 #include <proto/intuition.h>
@@ -68,17 +69,8 @@ static qboolean use_c2p = false;
 static int currentBitMap;
 static struct ScreenBuffer *sbuf[2];
 
-#define C2P_BITMAP
-
-#ifdef C2P_BITMAP
 typedef void (*c2p_write_bm_func)(REG(d0, WORD chunkyx), REG(d1, WORD chunkyy), REG(d2, WORD offsx), REG(d3, WORD offsy), REG(a0, APTR chunkyscreen), REG(a1, struct BitMap *bitmap));
 static c2p_write_bm_func c2p_write_bm;
-#else
-typedef void (*c2p_init_func)(REG(d0, WORD chunkyx), REG(d1, WORD chunkyy), REG(d3, WORD scroffsy), REG(d5, LONG bplsize));
-typedef void (*c2p_write_func)(REG(a0, APTR c2pscreen), REG(a1, APTR bitplanes));
-static c2p_init_func c2p_init;
-static c2p_write_func c2p_write;
-#endif
 
 ASM_LINKAGE_BEGIN
 extern void c2p1x1_8_c5_030_smcinit(REG(d0, WORD chunkyx), REG(d1, WORD chunkyy), REG(d3, WORD scroffsy), REG(d5, LONG bplsize));
@@ -575,6 +567,12 @@ static qboolean VID_SetMode (int modenum, const unsigned char *palette)
 		#if defined(PLATFORM_AMIGAOS3) && defined(USE_C2P)
 		struct BitMap *bm;
 		#endif
+		struct TagItem vctl[] =
+		{
+			{VTAG_BORDERBLANK_SET, TRUE},
+			{VC_IntermediateCLUpdate, FALSE},
+			{VTAG_END_CM, 0}
+		};
 
 		/*ModeID = BestCModeIDTags(
 			CYBRBIDTG_Depth, 8,
@@ -589,6 +587,9 @@ static qboolean VID_SetMode (int modenum, const unsigned char *palette)
 			SA_Height, modelist[modenum].height,
 			SA_Depth, 8,
 			SA_Quiet, TRUE,
+			SA_Draggable, FALSE,
+			SA_Type, CUSTOMSCREEN,
+			SA_VideoControl, (IPTR)vctl,
 			TAG_DONE);
 
 		#if defined(PLATFORM_AMIGAOS3) && defined(USE_C2P)
@@ -600,9 +601,6 @@ static qboolean VID_SetMode (int modenum, const unsigned char *palette)
 			if ((sbuf[0] = AllocScreenBuffer(screen, 0, SB_SCREEN_BITMAP)) && (sbuf[1] = AllocScreenBuffer(screen, 0, 0)))
 			{
 				use_c2p = true;
-				#ifndef C2P_BITMAP
-				c2p_init(modelist[modenum].width, modelist[modenum].height, 0, bm->BytesPerRow*bm->Rows);
-				#endif
 				// this fixes some RTG modes which would otherwise display garbage on the 1st buffer swap
 				//VID_Update(NULL);
 			}
@@ -756,7 +754,7 @@ void VID_SetPalette(const unsigned char *palette)
 
 	if (screen)
 	{
-		ULONG spal[1 + (256 * 3) + 1];
+		static ULONG spal[1 + (256 * 3) + 1];
 		ULONG *sp = spal;
 
 		*sp++ = 256 << 16;
@@ -815,29 +813,15 @@ void VID_Init (const unsigned char *palette)
 #endif
 
 #ifdef PLATFORM_AMIGAOS3
-	CyberGfxBase = OpenLibrary("cybergraphics.library", 0);
+	CyberGfxBase = OpenLibrary("cybergraphics.library", 41);
 	/*if (!CyberGfxBase)
 		Sys_Error ("Cannot open cybergraphics.library!");*/
 
 #ifdef USE_C2P
 	if (SysBase->AttnFlags & AFF_68040)
-	{
-#ifdef C2P_BITMAP
 		c2p_write_bm = c2p1x1_8_c5_bm_040;
-#else
-		c2p_init = c2p1x1_8_c5_040_init;
-		c2p_write = c2p1x1_8_c5_040;
-#endif
-	}
 	else
-	{
-#ifdef C2P_BITMAP
 		c2p_write_bm = c2p1x1_8_c5_bm;
-#else
-		c2p_init = c2p1x1_8_c5_030_smcinit;
-		c2p_write = c2p1x1_8_c5_030;
-#endif
-	}
 #endif
 #endif
 
@@ -1018,11 +1002,7 @@ static void FlipScreen (vrect_t *rects)
 	if (use_c2p)
 	{
 		currentBitMap ^= 1;
-#ifdef C2P_BITMAP
 		c2p_write_bm(vid.width, vid.height, 0, 0, vid.buffer, sbuf[currentBitMap]->sb_BitMap);
-#else
-		c2p_write(vid.buffer, sbuf[currentBitMap]->sb_BitMap->Planes[0]);
-#endif
 		ChangeScreenBuffer(screen, sbuf[currentBitMap]);
 		return;
 	}

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -1003,7 +1003,7 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 CFLAGS  += -fno-omit-frame-pointer
 else
 # these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-move-loop-invariants
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexen2/server/Makefile
+++ b/engine/hexen2/server/Makefile
@@ -285,7 +285,7 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 CFLAGS  += -fno-omit-frame-pointer
 else
 # these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-move-loop-invariants
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexen2/server/sys_amiga.c
+++ b/engine/hexen2/server/sys_amiga.c
@@ -320,8 +320,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	if (!apath.ap_Base)
-		return;
+	/*if (!apath.ap_Base)
+		return;*/
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/engine/hexen2/server/sys_amiga.c
+++ b/engine/hexen2/server/sys_amiga.c
@@ -282,7 +282,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath.ap_Base)
+	if (pattern_str)
 		Sys_Error ("Sys_FindFirst without FindClose");
 
 	memset(&apath, 0, sizeof(apath));
@@ -306,7 +306,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 
 const char *Sys_FindNextFile (void)
 {
-	if (!apath.ap_Base)
+	if (!pattern_str)
 		return NULL;
 
 	while (MatchNext(&apath) == 0)
@@ -320,8 +320,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	/*if (!apath.ap_Base)
-		return;*/
+	if (!pattern_str)
+		return;
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/engine/hexen2/server/sys_amiga.c
+++ b/engine/hexen2/server/sys_amiga.c
@@ -238,8 +238,7 @@ filenames only, not a dirent struct. this is
 what we presently need in this engine.
 =================================================
 */
-#define PATH_SIZE 1024
-static struct AnchorPath *apath;
+static struct AnchorPath apath;
 static BPTR oldcurrentdir;
 static STRPTR pattern_str;
 
@@ -283,33 +282,23 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath)
+	if (apath.ap_Base)
 		Sys_Error ("Sys_FindFirst without FindClose");
 
-	apath = (struct AnchorPath *) AllocVec (sizeof(struct AnchorPath) + PATH_SIZE, MEMF_CLEAR);
-	if (!apath)
-		return NULL;
-
-	apath->ap_Strlen = PATH_SIZE;
-	apath->ap_BreakBits = 0;
-	apath->ap_Flags = 0;  /* APF_DOWILD */
+	memset(&apath, 0, sizeof(apath));
 
 	newdir = Lock((const STRPTR) path, SHARED_LOCK);
 	if (newdir)
 		oldcurrentdir = CurrentDir(newdir);
 	else
-	{
-		FreeVec(apath);
-		apath = NULL;
 		return NULL;
-	}
 
 	pattern_str = pattern_helper (pattern);
 
-	if (MatchFirst((const STRPTR) pattern_str, apath) == 0)
+	if (MatchFirst((const STRPTR) pattern_str, &apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return Sys_FindNextFile();
@@ -317,13 +306,13 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 
 const char *Sys_FindNextFile (void)
 {
-	if (!apath)
+	if (!apath.ap_Base)
 		return NULL;
 
-	while (MatchNext(apath) == 0)
+	while (MatchNext(&apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return NULL;
@@ -331,13 +320,11 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	if (!apath)
+	if (!apath.ap_Base)
 		return;
-	MatchEnd(apath);
-	FreeVec(apath);
+	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;
-	apath = NULL;
 	Z_Free(pattern_str);
 	pattern_str = NULL;
 }

--- a/engine/hexen2/sys_amiga.c
+++ b/engine/hexen2/sys_amiga.c
@@ -335,8 +335,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	if (!apath.ap_Base)
-		return;
+	/*if (!apath.ap_Base)
+		return;*/
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/engine/hexen2/sys_amiga.c
+++ b/engine/hexen2/sys_amiga.c
@@ -297,7 +297,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath.ap_Base)
+	if (pattern_str)
 		Sys_Error ("Sys_FindFirst without FindClose");
 
 	memset(&apath, 0, sizeof(apath));
@@ -321,7 +321,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 
 const char *Sys_FindNextFile (void)
 {
-	if (!apath.ap_Base)
+	if (!pattern_str)
 		return NULL;
 
 	while (MatchNext(&apath) == 0)
@@ -335,8 +335,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	/*if (!apath.ap_Base)
-		return;*/
+	if (!pattern_str)
+		return;
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/engine/hexen2/sys_amiga.c
+++ b/engine/hexen2/sys_amiga.c
@@ -253,8 +253,7 @@ filenames only, not a dirent struct. this is
 what we presently need in this engine.
 =================================================
 */
-#define PATH_SIZE 1024
-static struct AnchorPath *apath;
+static struct AnchorPath apath;
 static BPTR oldcurrentdir;
 static STRPTR pattern_str;
 
@@ -298,33 +297,23 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath)
+	if (apath.ap_Base)
 		Sys_Error ("Sys_FindFirst without FindClose");
 
-	apath = (struct AnchorPath *) AllocVec (sizeof(struct AnchorPath) + PATH_SIZE, MEMF_CLEAR);
-	if (!apath)
-		return NULL;
-
-	apath->ap_Strlen = PATH_SIZE;
-	apath->ap_BreakBits = 0;
-	apath->ap_Flags = 0;  /* APF_DOWILD */
+	memset(&apath, 0, sizeof(apath));
 
 	newdir = Lock((const STRPTR) path, SHARED_LOCK);
 	if (newdir)
 		oldcurrentdir = CurrentDir(newdir);
 	else
-	{
-		FreeVec(apath);
-		apath = NULL;
 		return NULL;
-	}
 
 	pattern_str = pattern_helper (pattern);
 
-	if (MatchFirst((const STRPTR) pattern_str, apath) == 0)
+	if (MatchFirst((const STRPTR) pattern_str, &apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return Sys_FindNextFile();
@@ -332,13 +321,13 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 
 const char *Sys_FindNextFile (void)
 {
-	if (!apath)
+	if (!apath.ap_Base)
 		return NULL;
 
-	while (MatchNext(apath) == 0)
+	while (MatchNext(&apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return NULL;
@@ -346,13 +335,11 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	if (!apath)
+	if (!apath.ap_Base)
 		return;
-	MatchEnd(apath);
-	FreeVec(apath);
+	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;
-	apath = NULL;
 	Z_Free(pattern_str);
 	pattern_str = NULL;
 }

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -964,7 +964,7 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 CFLAGS  += -fno-omit-frame-pointer
 else
 # these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-move-loop-invariants
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexenworld/client/sys_amiga.c
+++ b/engine/hexenworld/client/sys_amiga.c
@@ -329,8 +329,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	if (!apath.ap_Base)
-		return;
+	/*if (!apath.ap_Base)
+		return;*/
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/engine/hexenworld/client/sys_amiga.c
+++ b/engine/hexenworld/client/sys_amiga.c
@@ -291,7 +291,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath.ap_Base)
+	if (pattern_str)
 		Sys_Error ("Sys_FindFirst without FindClose");
 
 	memset(&apath, 0, sizeof(apath));
@@ -315,7 +315,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 
 const char *Sys_FindNextFile (void)
 {
-	if (!apath.ap_Base)
+	if (!pattern_str)
 		return NULL;
 
 	while (MatchNext(&apath) == 0)
@@ -329,8 +329,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	/*if (!apath.ap_Base)
-		return;*/
+	if (!pattern_str)
+		return;
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/engine/hexenworld/server/Makefile
+++ b/engine/hexenworld/server/Makefile
@@ -278,7 +278,7 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 CFLAGS  += -fno-omit-frame-pointer
 else
 # these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-move-loop-invariants
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexenworld/server/sys_amiga.c
+++ b/engine/hexenworld/server/sys_amiga.c
@@ -236,8 +236,7 @@ filenames only, not a dirent struct. this is
 what we presently need in this engine.
 =================================================
 */
-#define PATH_SIZE 1024
-static struct AnchorPath *apath;
+static struct AnchorPath apath;
 static BPTR oldcurrentdir;
 static STRPTR pattern_str;
 
@@ -281,33 +280,23 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath)
+	if (apath.ap_Base)
 		Sys_Error ("Sys_FindFirst without FindClose");
 
-	apath = (struct AnchorPath *) AllocVec (sizeof(struct AnchorPath) + PATH_SIZE, MEMF_CLEAR);
-	if (!apath)
-		return NULL;
-
-	apath->ap_Strlen = PATH_SIZE;
-	apath->ap_BreakBits = 0;
-	apath->ap_Flags = 0;  /* APF_DOWILD */
+	memset(&apath, 0, sizeof(apath));
 
 	newdir = Lock((const STRPTR) path, SHARED_LOCK);
 	if (newdir)
 		oldcurrentdir = CurrentDir(newdir);
 	else
-	{
-		FreeVec(apath);
-		apath = NULL;
 		return NULL;
-	}
 
 	pattern_str = pattern_helper (pattern);
 
-	if (MatchFirst((const STRPTR) pattern_str, apath) == 0)
+	if (MatchFirst((const STRPTR) pattern_str, &apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return Sys_FindNextFile();
@@ -315,13 +304,13 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 
 const char *Sys_FindNextFile (void)
 {
-	if (!apath)
+	if (!apath.ap_Base)
 		return NULL;
 
-	while (MatchNext(apath) == 0)
+	while (MatchNext(&apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return NULL;
@@ -329,13 +318,11 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	if (!apath)
+	if (!apath.ap_Base)
 		return;
-	MatchEnd(apath);
-	FreeVec(apath);
+	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;
-	apath = NULL;
 	Z_Free(pattern_str);
 	pattern_str = NULL;
 }

--- a/engine/hexenworld/server/sys_amiga.c
+++ b/engine/hexenworld/server/sys_amiga.c
@@ -318,8 +318,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	if (!apath.ap_Base)
-		return;
+	/*if (!apath.ap_Base)
+		return;*/
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/engine/hexenworld/server/sys_amiga.c
+++ b/engine/hexenworld/server/sys_amiga.c
@@ -280,7 +280,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath.ap_Base)
+	if (pattern_str)
 		Sys_Error ("Sys_FindFirst without FindClose");
 
 	memset(&apath, 0, sizeof(apath));
@@ -304,7 +304,7 @@ const char *Sys_FindFirstFile (const char *path, const char *pattern)
 
 const char *Sys_FindNextFile (void)
 {
-	if (!apath.ap_Base)
+	if (!pattern_str)
 		return NULL;
 
 	while (MatchNext(&apath) == 0)
@@ -318,8 +318,8 @@ const char *Sys_FindNextFile (void)
 
 void Sys_FindClose (void)
 {
-	/*if (!apath.ap_Base)
-		return;*/
+	if (!pattern_str)
+		return;
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/utils/common/util_io.c
+++ b/utils/common/util_io.c
@@ -510,8 +510,8 @@ const char *Q_FindNextFile (void)
 
 void Q_FindClose (void)
 {
-	if (!apath.ap_Base)
-		return;
+	/*if (!apath.ap_Base)
+		return;*/
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/utils/common/util_io.c
+++ b/utils/common/util_io.c
@@ -472,7 +472,7 @@ const char *Q_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath.ap_Base)
+	if (pattern_str)
 		COM_Error ("FindFirst without FindClose");
 
 	memset(&apath, 0, sizeof(apath));
@@ -496,7 +496,7 @@ const char *Q_FindFirstFile (const char *path, const char *pattern)
 
 const char *Q_FindNextFile (void)
 {
-	if (!apath.ap_Base)
+	if (!pattern_str)
 		return NULL;
 
 	while (MatchNext(&apath) == 0)
@@ -510,8 +510,8 @@ const char *Q_FindNextFile (void)
 
 void Q_FindClose (void)
 {
-	/*if (!apath.ap_Base)
-		return;*/
+	if (!pattern_str)
+		return;
 	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;

--- a/utils/common/util_io.c
+++ b/utils/common/util_io.c
@@ -428,8 +428,7 @@ int Q_FileType (const char *path)
 
 #elif defined(PLATFORM_AMIGA)
 
-#define PATH_SIZE 1024
-static struct AnchorPath *apath;
+static struct AnchorPath apath;
 static BPTR oldcurrentdir;
 static STRPTR pattern_str;
 
@@ -473,33 +472,23 @@ const char *Q_FindFirstFile (const char *path, const char *pattern)
 {
 	BPTR newdir;
 
-	if (apath)
+	if (apath.ap_Base)
 		COM_Error ("FindFirst without FindClose");
 
-	apath = (struct AnchorPath *) AllocVec (sizeof(struct AnchorPath) + PATH_SIZE, MEMF_CLEAR);
-	if (!apath)
-		return NULL;
-
-	apath->ap_Strlen = PATH_SIZE;
-	apath->ap_BreakBits = 0;
-	apath->ap_Flags = 0;  /* APF_DOWILD */
+	memset(&apath, 0, sizeof(apath));
 
 	newdir = Lock((const STRPTR) path, SHARED_LOCK);
 	if (newdir)
 		oldcurrentdir = CurrentDir(newdir);
 	else
-	{
-		FreeVec(apath);
-		apath = NULL;
 		return NULL;
-	}
 
 	pattern_str = pattern_helper (pattern);
 
-	if (MatchFirst((const STRPTR) pattern_str, apath) == 0)
+	if (MatchFirst((const STRPTR) pattern_str, &apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return Q_FindNextFile();
@@ -507,13 +496,13 @@ const char *Q_FindFirstFile (const char *path, const char *pattern)
 
 const char *Q_FindNextFile (void)
 {
-	if (!apath)
+	if (!apath.ap_Base)
 		return NULL;
 
-	while (MatchNext(apath) == 0)
+	while (MatchNext(&apath) == 0)
 	{
-	    if (apath->ap_Info.fib_DirEntryType < 0)
-		return (const char *) (apath->ap_Info.fib_FileName);
+	    if (apath.ap_Info.fib_DirEntryType < 0)
+		return (const char *) (apath.ap_Info.fib_FileName);
 	}
 
 	return NULL;
@@ -521,13 +510,11 @@ const char *Q_FindNextFile (void)
 
 void Q_FindClose (void)
 {
-	if (apath == NULL)
+	if (!apath.ap_Base)
 		return;
-	MatchEnd(apath);
-	FreeVec(apath);
+	MatchEnd(&apath);
 	UnLock(CurrentDir(oldcurrentdir));
 	oldcurrentdir = 0;
-	apath = NULL;
 	free (pattern_str);
 	pattern_str = NULL;
 }


### PR DESCRIPTION
I did some cleanup for the existing Amiga code to simplify it a bit. The input handling should be a bit faster too.
AnchorPath was an interesting one, it turns out you don't have to allocate memory for ap_Buf if you don't need the full path and only use ap_Info. In this case ap_Strlen is simply set to 0.