### PR TITLE
Fixed the minimum stack on AmigaOS 3 with LibNIX and reduce it to 256 KB

### DIFF
--- a/engine/hexen2/server/sys_amiga.c
+++ b/engine/hexen2/server/sys_amiga.c
@@ -29,6 +29,8 @@
 
 #if defined(__LP64__)
 #define MIN_STACK_SIZE 0x200000 /* 2 MB stack */
+#elif defined(PLATFORM_AMIGAOS3)
+#define MIN_STACK_SIZE 0x40000 /* 256 KB stack */
 #else
 #define MIN_STACK_SIZE 0x100000 /* 1 MB stack */
 #endif
@@ -37,6 +39,11 @@
 int __stack_size = MIN_STACK_SIZE;
 #else
 int __stack = MIN_STACK_SIZE;
+#ifdef PLATFORM_AMIGAOS3
+/* this pulls in stackswap.o */
+extern void __stkinit(void);
+void * __x = __stkinit;
+#endif
 #endif
 #ifdef __AROS__
 #include "incstack.h"

--- a/engine/hexen2/sys_amiga.c
+++ b/engine/hexen2/sys_amiga.c
@@ -37,6 +37,8 @@
 
 #if defined(__LP64__)
 #define MIN_STACK_SIZE 0x200000 /* 2 MB stack */
+#elif defined(PLATFORM_AMIGAOS3)
+#define MIN_STACK_SIZE 0x40000 /* 256 KB stack */
 #else
 #define MIN_STACK_SIZE 0x100000 /* 1 MB stack */
 #endif
@@ -45,6 +47,11 @@
 int __stack_size = MIN_STACK_SIZE;
 #else
 int __stack = MIN_STACK_SIZE;
+#ifdef PLATFORM_AMIGAOS3
+/* this pulls in stackswap.o */
+extern void __stkinit(void);
+void * __x = __stkinit;
+#endif
 #endif
 #ifdef __AROS__
 #include "incstack.h"

--- a/engine/hexenworld/client/sys_amiga.c
+++ b/engine/hexenworld/client/sys_amiga.c
@@ -37,6 +37,8 @@
 
 #if defined(__LP64__)
 #define MIN_STACK_SIZE 0x200000 /* 2 MB stack */
+#elif defined(PLATFORM_AMIGAOS3)
+#define MIN_STACK_SIZE 0x40000 /* 256 KB stack */
 #else
 #define MIN_STACK_SIZE 0x100000 /* 1 MB stack */
 #endif
@@ -45,6 +47,11 @@
 int __stack_size = MIN_STACK_SIZE;
 #else
 int __stack = MIN_STACK_SIZE;
+#ifdef PLATFORM_AMIGAOS3
+/* this pulls in stackswap.o */
+extern void __stkinit(void);
+void * __x = __stkinit;
+#endif
 #endif
 #ifdef __AROS__
 #include "incstack.h"

--- a/engine/hexenworld/server/sys_amiga.c
+++ b/engine/hexenworld/server/sys_amiga.c
@@ -28,6 +28,8 @@
 
 #if defined(__LP64__)
 #define MIN_STACK_SIZE 0x200000 /* 2 MB stack */
+#elif defined(PLATFORM_AMIGAOS3)
+#define MIN_STACK_SIZE 0x40000 /* 256 KB stack */
 #else
 #define MIN_STACK_SIZE 0x100000 /* 1 MB stack */
 #endif
@@ -36,6 +38,11 @@
 int __stack_size = MIN_STACK_SIZE;
 #else
 int __stack = MIN_STACK_SIZE;
+#ifdef PLATFORM_AMIGAOS3
+/* this pulls in stackswap.o */
+extern void __stkinit(void);
+void * __x = __stkinit;
+#endif
 #endif
 #ifdef __AROS__
 #include "incstack.h"


### PR DESCRIPTION
I noticed that stackswap.o wasn't getting linked, so the stack had to be manually increased before running the game. I also reduced the stack a bit, as 1MB proved to be overkill. 