### PR TITLE
amiga: added cdplayer.library support

### DIFF
--- a/engine/h2shared/cd_amiga.c
+++ b/engine/h2shared/cd_amiga.c
@@ -1,0 +1,532 @@
+/* cd_amiga.c
+ * Copyright (C) 1996-1997  Id Software, Inc.
+ * Copyright (C) 2021 Szilard Biro <col.lawrence@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "quakedef.h"
+#include "cdaudio.h"
+
+#include <dos/dostags.h>
+#include <dos/dosextens.h>
+#include <dos/filehandler.h>
+#include <libraries/cdplayer.h>
+#include <proto/cdplayer.h>
+#include <proto/dos.h>
+#include <proto/exec.h>
+
+static qboolean cdValid = false;
+static qboolean	playing = false;
+static qboolean	wasPlaying = false;
+static qboolean	initialized = false;
+static qboolean	enabled = true;
+static qboolean playLooping = false;
+static byte	remap[100];
+static byte	playTrack;
+static byte	maxTrack;
+
+struct Library *CDPlayerBase = NULL;
+static struct IOStdReq *cdRequest = NULL;
+static struct MsgPort *cdPort = NULL;
+static BYTE	cdDevice = -1;
+static struct CD_TOC cdTOC;
+static const char	default_dev[] = "CD0:"; /* user can always do -cddev */
+static const char	*cd_dev = default_dev;
+
+static float	old_cdvolume;
+static qboolean	hw_vol_works = true;
+static struct CD_Volume	orig_vol;	/* original setting to be restored upon exit */
+static struct CD_Volume	drv_vol;	/* the volume setting we'll be using */
+
+
+static void CDAudio_Eject(void)
+{
+	BYTE error;
+
+	if (cdDevice == -1 || !enabled)
+		return;
+
+	error = CDEject(cdRequest);
+	if (error)
+		Con_DPrintf("CDEject failed (%d)\n", (int)error);
+}
+
+static int CDAudio_GetAudioDiskInfo(void)
+{
+	BYTE error;
+
+	if (cdDevice == -1)
+		return -1;
+
+	cdValid = false;
+
+	error = CDReadTOC(&cdTOC, cdRequest);
+	if (error)
+	{
+		Con_DPrintf("CDReadTOC failed (%d)\n", (int)error);
+		return -1;
+	}
+
+	if (cdTOC.cdc_NumTracks < 1)
+	{
+		Con_DPrintf("CDAudio: no music tracks\n");
+		return -1;
+	}
+
+	cdValid = true;
+	maxTrack = cdTOC.cdc_NumTracks;
+
+	return 0;
+}
+
+int CDAudio_Play(byte track, qboolean looping)
+{
+	BYTE error;
+
+	if (cdDevice == -1 || !enabled)
+		return -1;
+
+	if (!cdValid)
+	{
+		CDAudio_GetAudioDiskInfo();
+		if (!cdValid)
+			return -1;
+	}
+
+	track = remap[track];
+
+	if (track < 1 || track > maxTrack)
+	{
+		Con_DPrintf("CDAudio: Bad track number %u.\n", track);
+		return -1;
+	}
+
+	/* don't try to play a non-audio track */
+	if (cdTOC.cdc_Flags[track])
+	{
+		Con_Printf("CDAudio: track %i is not audio\n", track);
+		return -1;
+	}
+
+	if (playing)
+	{
+		if (playTrack == track)
+			return 0;
+		CDAudio_Stop();
+	}
+
+	error = CDPlay(track, track, cdRequest);
+	if (error)
+	{
+		Con_DPrintf("CDPlay failed (%d)\n", (int)error);
+		return -1;
+	}
+
+	playLooping = looping;
+	playTrack = track;
+	playing = true;
+
+	if (bgmvolume.value == 0) /* don't bother advancing */
+		CDAudio_Pause ();
+
+	return 0;
+}
+
+void CDAudio_Stop(void)
+{
+	BYTE error;
+
+	if (cdDevice == -1 || !enabled)
+		return;
+
+	if (!playing)
+		return;
+
+	error = CDStop(cdRequest);
+	if (error)
+		Con_DPrintf("CDStop failed (%d)\n", (int)error);
+
+	wasPlaying = false;
+	playing = false;
+}
+
+void CDAudio_Pause(void)
+{
+	BYTE error;
+
+	if (cdDevice == -1 || !enabled)
+		return;
+
+	if (!playing)
+		return;
+
+	error = CDResume(TRUE, cdRequest);
+	if (error)
+		Con_DPrintf("CDResume failed (%d)\n", (int)error);
+
+	wasPlaying = playing;
+	playing = false;
+}
+
+void CDAudio_Resume(void)
+{
+	BYTE error;
+
+	if (cdDevice == -1 || !enabled)
+		return;
+
+	if (!cdValid)
+		return;
+
+	if (!wasPlaying)
+		return;
+
+	error = CDResume(FALSE, cdRequest);
+	if (error)
+		Con_DPrintf("CDResume failed (%d)\n", (int)error);
+	playing = true;
+}
+
+static void CD_f (void)
+{
+	const char	*command;
+	int		ret, n;
+
+	if (Cmd_Argc() < 2)
+	{
+		Con_Printf("commands:");
+		Con_Printf("on, off, reset, remap, \n");
+		Con_Printf("play, stop, loop, pause, resume\n");
+		Con_Printf("eject, close, info\n");
+		return;
+	}
+
+	command = Cmd_Argv (1);
+
+	if (q_strcasecmp(command, "on") == 0)
+	{
+		enabled = true;
+		return;
+	}
+
+	if (q_strcasecmp(command, "off") == 0)
+	{
+		if (playing)
+			CDAudio_Stop();
+		enabled = false;
+		return;
+	}
+
+	if (q_strcasecmp(command, "reset") == 0)
+	{
+		enabled = true;
+		if (playing)
+			CDAudio_Stop();
+		for (n = 0; n < 100; n++)
+			remap[n] = n;
+		CDAudio_GetAudioDiskInfo();
+		return;
+	}
+
+	if (q_strcasecmp(command, "remap") == 0)
+	{
+		ret = Cmd_Argc() - 2;
+		if (ret <= 0)
+		{
+			for (n = 1; n < 100; n++)
+				if (remap[n] != n)
+					Con_Printf("  %u -> %u\n", n, remap[n]);
+			return;
+		}
+		for (n = 1; n <= ret; n++)
+			remap[n] = atoi(Cmd_Argv (n+1));
+		return;
+	}
+
+	if (!cdValid)
+	{
+		CDAudio_GetAudioDiskInfo();
+		if (!cdValid)
+		{
+			Con_Printf("No CD in player.\n");
+			return;
+		}
+	}
+
+	if (q_strcasecmp(command, "play") == 0)
+	{
+		CDAudio_Play((byte)atoi(Cmd_Argv (2)), false);
+		return;
+	}
+
+	if (q_strcasecmp(command, "loop") == 0)
+	{
+		CDAudio_Play((byte)atoi(Cmd_Argv (2)), true);
+		return;
+	}
+
+	if (q_strcasecmp(command, "stop") == 0)
+	{
+		CDAudio_Stop();
+		return;
+	}
+
+	if (q_strcasecmp(command, "pause") == 0)
+	{
+		CDAudio_Pause();
+		return;
+	}
+
+	if (q_strcasecmp(command, "resume") == 0)
+	{
+		CDAudio_Resume();
+		return;
+	}
+
+	if (q_strcasecmp(command, "eject") == 0)
+	{
+		if (playing)
+			CDAudio_Stop();
+		CDAudio_Eject();
+		cdValid = false;
+		return;
+	}
+
+	if (q_strcasecmp(command, "info") == 0)
+	{
+		Con_Printf("%u tracks\n", maxTrack);
+		if (playing)
+			Con_Printf("Currently %s track %u\n", playLooping ? "looping" : "playing", playTrack);
+		else if (wasPlaying)
+			Con_Printf("Paused %s track %u\n", playLooping ? "looping" : "playing", playTrack);
+		Con_Printf("Volume is %f\n", bgmvolume.value);
+		return;
+	}
+}
+
+static qboolean CD_GetVolume (struct CD_Volume *vol)
+{
+	BYTE error;
+	error = CDGetVolume(vol, cdRequest);
+	if (error)
+	{
+		Con_DPrintf("CDGetVolume failed (%d)\n", (int)error);
+		return false;
+	}
+	return true;
+}
+
+static qboolean CD_SetVolume (struct CD_Volume *vol)
+{
+	BYTE error;
+	error = CDSetVolume(vol, cdRequest);
+	if (error)
+	{
+		Con_DPrintf("CDSetVolume failed (%d)\n", (int)error);
+		return false;
+	}
+	return true;
+}
+
+static qboolean CDAudio_SetVolume (float value)
+{
+	if (cdDevice == -1 || !enabled)
+		return false;
+
+	old_cdvolume = value;
+
+	if (value == 0.0f)
+		CDAudio_Pause ();
+	else
+		CDAudio_Resume();
+
+	if (!hw_vol_works)
+	{
+		return false;
+	}
+	else
+	{
+		drv_vol.cdv_Chan0 = drv_vol.cdv_Chan2 =
+		drv_vol.cdv_Chan1 = drv_vol.cdv_Chan3 = value * 255.0f;
+		return CD_SetVolume (&drv_vol);
+	}
+}
+
+void CDAudio_Update(void)
+{
+	BOOL status;
+	static double lastCheck;
+
+	if (cdDevice == -1 || !enabled)
+		return;
+
+	if (old_cdvolume != bgmvolume.value)
+		CDAudio_SetVolume (bgmvolume.value);
+
+	if (playing && lastCheck < realtime)
+	{
+		lastCheck = realtime + 2.0; /* two seconds between chks */
+		status = CDActive(cdRequest);
+		if (!status)
+		{
+			playing = false;
+			if (playLooping)
+				CDAudio_Play(playTrack, true);
+		}
+	}
+}
+
+static void CD_CloseDevice(void)
+{
+	if (cdRequest)
+	{
+		if (!cdDevice)
+		{
+			CloseDevice((struct IORequest *)cdRequest);
+			cdDevice = -1;
+		}
+		DeleteIORequest(cdRequest);
+		cdRequest = NULL;
+	}
+	if (cdPort)
+	{
+		DeleteMsgPort(cdPort);
+		cdPort = NULL;
+	}
+}
+
+static int CD_OpenDevice(const char *volume)
+{
+	struct FileLock *fl;
+	struct DosList *dol = NULL;
+	struct DosList *doslist;
+	BPTR lock;
+	struct Process *me;
+	APTR oldwindow;
+
+	me = (struct Process *)FindTask(NULL);
+	oldwindow = me->pr_WindowPtr;
+	me->pr_WindowPtr = (APTR)-1;
+	lock = Lock((STRPTR)volume, ACCESS_READ);
+	me->pr_WindowPtr = oldwindow;
+
+	if (!lock)
+		return -1; // IoErr()
+
+	UnLock(lock);
+
+	// look for the device
+	fl = (struct FileLock *)BADDR(lock);
+	if ((doslist = LockDosList(LDF_DEVICES | LDF_READ)))
+	{
+		while ((doslist = NextDosEntry(doslist, LDF_DEVICES)))
+		{
+			if (doslist->dol_Task == fl->fl_Task)
+			{
+				dol = doslist;
+				break;
+			}
+		}
+		UnLockDosList(LDF_DEVICES | LDF_READ);
+	}
+
+	if (dol)
+	{
+		struct FileSysStartupMsg *fssm = (struct FileSysStartupMsg *)BADDR(dol->dol_misc.dol_handler.dol_Startup);
+		if ((ULONG)fssm > 0x400 && TypeOfMem(fssm) && fssm->fssm_Unit <= 0x00ffffff)
+		{
+			STRPTR device = (STRPTR)BADDR(fssm->fssm_Device);
+			if (device && TypeOfMem(device) && device[0] != 0 && device[1] != '\0')
+			{
+				if ((cdPort = CreateMsgPort()))
+				{
+					if ((cdRequest = (struct IOStdReq *)CreateIORequest(cdPort, sizeof(struct IOStdReq))))
+					{
+						cdDevice = OpenDevice(device + 1, fssm->fssm_Unit, (struct IORequest *)cdRequest, 0);
+						return cdDevice;
+					}
+				}
+			}
+		}
+	}
+
+	CD_CloseDevice();
+
+	return -1;
+}
+
+int CDAudio_Init(void)
+{
+	int i;
+
+	if (safemode || COM_CheckParm("-nocdaudio"))
+		return -1;
+
+	if (!(CDPlayerBase = OpenLibrary((STRPTR)CDPLAYERNAME, CDPLAYERVERSION)))
+	{
+		Con_Printf ("%s: can't open cdplayer.library, CD Audio is disabled.\n", __thisfunc__);
+		return -1;
+	}
+
+	if ((i = COM_CheckParm("-cddev")) != 0 && i < com_argc - 1)
+		cd_dev = com_argv[i + 1];
+
+	if ((cdDevice = CD_OpenDevice(cd_dev)) == -1)
+	{
+		i = cdDevice;
+		Con_Printf("%s: open of \"%s\" failed (%d)\n",
+				__thisfunc__, cd_dev, i);
+		return -1;
+	}
+
+	for (i = 0; i < 100; i++)
+		remap[i] = i;
+	initialized = true;
+	enabled = true;
+	old_cdvolume = bgmvolume.value;
+
+	Con_Printf("CDAudio initialized (using cdplayer.library)\n");
+
+	if (CDAudio_GetAudioDiskInfo())
+	{
+		Con_Printf("%s: No CD in drive\n", __thisfunc__);
+		cdValid = false;
+	}
+
+	Cmd_AddCommand ("cd", CD_f);
+
+	hw_vol_works = CD_GetVolume (&orig_vol);
+	if (hw_vol_works)
+		hw_vol_works = CDAudio_SetVolume (bgmvolume.value);
+
+	return 0;
+}
+
+void CDAudio_Shutdown(void)
+{
+	if (!initialized)
+		return;
+	CDAudio_Stop();
+	if (hw_vol_works)
+		CD_SetVolume (&orig_vol);
+	CD_CloseDevice();
+	if (CDPlayerBase)
+	{
+		CloseLibrary(CDPlayerBase);
+		CDPlayerBase = NULL;
+	}
+}

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -1020,8 +1020,6 @@ USE_SDL=no
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no
 USE_SDLAUDIO=no
-# no native cdaudio code yet
-USE_CDAUDIO=no
 endif
 
 ifndef DEBUG
@@ -1431,7 +1429,7 @@ ifeq ($(TARGET_OS),morphos)
 SYSOBJ_CDA := cd_sdl.o
 endif
 ifeq ($(TARGET_OS),amigaos)
-SYSOBJ_CDA := cd_sdl.o
+SYSOBJ_CDA := cd_amiga.o
 endif
 # end of CDAudio objects
 endif

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -981,8 +981,6 @@ USE_SDL=no
 ifneq ($(USE_SDL),yes)
 USE_SDLCD=no
 USE_SDLAUDIO=no
-# no native cdaudio code yet
-USE_CDAUDIO=no
 endif
 
 ifndef DEBUG
@@ -1395,7 +1393,7 @@ ifeq ($(TARGET_OS),morphos)
 SYSOBJ_CDA := cd_sdl.o
 endif
 ifeq ($(TARGET_OS),amigaos)
-SYSOBJ_CDA := cd_sdl.o
+SYSOBJ_CDA := cd_amiga.o
 endif
 # end of CDAudio objects
 endif

--- a/oslibs/amigaos/include/clib/cdplayer_protos.h
+++ b/oslibs/amigaos/include/clib/cdplayer_protos.h
@@ -1,0 +1,27 @@
+#ifndef CDPLAYER_PROTOS_H
+#define CDPLAYER_PROTOS_H
+
+/*
+	Prototypes für die cdplayer.library  © 1995 by Patrick Hess
+	$VER: cdplayer_protos.h 1.0 (29.05.1995)
+*/
+
+#ifndef EXEC_TYPES_H
+#include <exec/types.h>
+#endif
+
+BYTE CDEject (struct IOStdReq *);
+BYTE CDPlay (UBYTE, UBYTE, struct IOStdReq *);
+BYTE CDResume (BOOL, struct IOStdReq *);
+BYTE CDStop (struct IOStdReq *);
+BYTE CDJump (ULONG, struct IOStdReq *);
+BOOL CDActive (struct IOStdReq *);
+ULONG CDCurrentTitle (struct IOStdReq *);
+BYTE CDTitleTime (struct CD_Time *, struct IOStdReq *);
+BYTE CDGetVolume (struct CD_Volume *, struct IOStdReq *);
+BYTE CDSetVolume (struct CD_Volume *, struct IOStdReq *);
+BYTE CDReadTOC (struct CD_TOC *, struct IOStdReq *);
+BYTE CDInfo (struct CD_Info *, struct IOStdReq *);
+
+#endif
+

--- a/oslibs/amigaos/include/inline/cdplayer.h
+++ b/oslibs/amigaos/include/inline/cdplayer.h
@@ -1,0 +1,126 @@
+/* Automatically generated header (sfdc 1.11)! Do not edit! */
+
+#ifndef _INLINE_CDPLAYER_H
+#define _INLINE_CDPLAYER_H
+
+#ifndef _SFDC_VARARG_DEFINED
+#define _SFDC_VARARG_DEFINED
+#ifdef __HAVE_IPTR_ATTR__
+typedef APTR _sfdc_vararg __attribute__((iptr));
+#else
+typedef ULONG _sfdc_vararg;
+#endif /* __HAVE_IPTR_ATTR__ */
+#endif /* _SFDC_VARARG_DEFINED */
+
+#ifndef __INLINE_MACROS_H
+#include <inline/macros.h>
+#endif /* !__INLINE_MACROS_H */
+
+#ifndef CDPLAYER_BASE_NAME
+#define CDPLAYER_BASE_NAME CDPlayerBase
+#endif /* !CDPLAYER_BASE_NAME */
+
+#ifndef LP2A5
+#define LP2A5(offs, rt, name, t1, v1, r1, t2, v2, r2, bt, bn)	\
+({								\
+   t1 _##name##_v1 = (v1);					\
+   t2 _##name##_v2 = (v2);					\
+   rt _##name##_re2 =						\
+   ({								\
+      register int _d1 __asm("d1");				\
+      register int _a0 __asm("a0");				\
+      register int _a1 __asm("a1");				\
+      register rt _##name##_re __asm("d0");			\
+      register void *const _##name##_bn __asm("a6") = (bn);	\
+      register t1 _n1 __asm(#r1) = _##name##_v1;		\
+      register t2 _n2 __asm(#r2) = _##name##_v2;		\
+      __asm volatile ("exg d7,a5\n\tjsr a6@(-"#offs":W)\n\texg d7,a5"			\
+      : "=r" (_##name##_re), "=r" (_d1), "=r" (_a0), "=r" (_a1)	\
+      : "r" (_##name##_bn), "rf"(_n1), "rf"(_n2)		\
+      : "fp0", "fp1", "cc", "memory");				\
+      _##name##_re;						\
+   });								\
+   _##name##_re2;						\
+})
+#endif
+
+#ifndef LP3A5
+#define LP3A5(offs, rt, name, t1, v1, r1, t2, v2, r2, t3, v3, r3, bt, bn) \
+({								\
+   t1 _##name##_v1 = (v1);					\
+   t2 _##name##_v2 = (v2);					\
+   t3 _##name##_v3 = (v3);					\
+   rt _##name##_re2 =						\
+   ({								\
+      register int _d1 __asm("d1");				\
+      register int _a0 __asm("a0");				\
+      register int _a1 __asm("a1");				\
+      register rt _##name##_re __asm("d0");			\
+      register void *const _##name##_bn __asm("a6") = (bn);	\
+      register t1 _n1 __asm(#r1) = _##name##_v1;		\
+      register t2 _n2 __asm(#r2) = _##name##_v2;		\
+      register t3 _n3 __asm(#r3) = _##name##_v3;		\
+      __asm volatile ("exg d7,a5\n\tjsr a6@(-"#offs":W)\n\texg d7,a5"			\
+      : "=r" (_##name##_re), "=r" (_d1), "=r" (_a0), "=r" (_a1)	\
+      : "r" (_##name##_bn), "rf"(_n1), "rf"(_n2), "rf"(_n3)	\
+      : "fp0", "fp1", "cc", "memory");				\
+      _##name##_re;						\
+   });								\
+   _##name##_re2;						\
+})
+#endif
+
+#define CDEject(___io_ptr) \
+      LP1A5(0x1e, BYTE, CDEject , struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+/*
+#define CDPlay(___starttrack, ___endtrack, ___io_ptr) \
+      LP3A5(0x24, BYTE, CDPlay , UBYTE, ___starttrack, a0, UBYTE, ___endtrack, a1, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+*/
+#define CDPlay(___starttrack, ___endtrack, ___io_ptr) \
+      LP3A5(0x24, BYTE, CDPlay , ULONG, ___starttrack, a0, ULONG, ___endtrack, a1, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDResume(___Mode, ___io_ptr) \
+      LP2A5(0x2a, BYTE, CDResume , BOOL, ___Mode, a0, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDStop(___io_ptr) \
+      LP1A5(0x30, BYTE, CDStop , struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDJump(___Blocks, ___io_ptr) \
+      LP2A5(0x36, BYTE, CDJump , ULONG, ___Blocks, a0, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDActive(___io_ptr) \
+      LP1A5(0x3c, BOOL, CDActive , struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDCurrentTitle(___io_ptr) \
+      LP1A5(0x42, ULONG, CDCurrentTitle , struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDTitleTime(___cd_time, ___io_ptr) \
+      LP2A5(0x48, BYTE, CDTitleTime , struct CD_Time *, ___cd_time, a0, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDGetVolume(___vol, ___io_ptr) \
+      LP2A5(0x4e, BYTE, CDGetVolume , struct CD_Volume *, ___vol, a0, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDSetVolume(___vol, ___io_ptr) \
+      LP2A5(0x54, BYTE, CDSetVolume , struct CD_Volume *, ___vol, a0, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDReadTOC(___toc, ___io_ptr) \
+      LP2A5(0x5a, BYTE, CDReadTOC , struct CD_TOC *, ___toc, a0, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#define CDInfo(___cdi, ___io_ptr) \
+      LP2A5(0x60, BYTE, CDInfo , struct CD_Info *, ___cdi, a0, struct IOStdReq *, ___io_ptr, d7,\
+      , CDPLAYER_BASE_NAME)
+
+#endif /* !_INLINE_CDPLAYER_H */

--- a/oslibs/amigaos/include/libraries/cdplayer.h
+++ b/oslibs/amigaos/include/libraries/cdplayer.h
@@ -1,0 +1,93 @@
+#ifndef CDPLAYER_H
+#define CDPLAYER_H
+
+/*
+	Definitionen für die cdplayer.library  © 1995 by Patrick Hess
+
+	$VER: cdplayer_protos.h 1.0 (29.05.1995)
+*/
+
+#ifndef EXEC_TYPES_H
+#include <exec/types.h>
+#endif
+
+#define CDPLAYERNAME		"cdplayer.library"
+#define CDPLAYERVERSION		37L
+
+/* Macros für die Umrechnung der Adressen in Minuten und Sekunden */
+
+#define BASE2MIN(val)	((val)/75/60)
+#define BASE2SEC(val)	(((val)/75)%60)
+
+/* Tabel Of Contents - Inhaltsverzeichniss der CD */
+
+struct CD_TOC
+{
+	UBYTE cdc_NumTracks;	/* Anzahl der Tracks auf CD */
+	UBYTE cdc_ActTitle;	/* aktueller Titel, nur nach TOC-Lesen aktuell */
+	UBYTE cdc_Flags[100];	/* Pro Track: 0 = Musik, 1 = Daten */
+	ULONG cdc_Addr[100];	/* Pro Track: Start-Adressen */
+};
+
+/* aktuelle Position auf der CD, alles Adresse die mit dem Macros BASE2(MIN|SEC)
+   in Minuten/Sekunden umgerechnet werden müssen */
+
+struct CD_Time
+{
+	ULONG	cdt_TrackCurBase;	/* Adr: aktuelle Position Track */
+	ULONG	cdt_TrackRemainBase;	/* Adr: Restspielzeit Track */
+	ULONG	cdt_TrackCompleteBase;	/* Adr: Gesammspielzeit Track */
+	ULONG	cdt_AllCurBase;		/* Adr: aktuelle Position CD */
+	ULONG	cdt_AllRemainBase;	/* Adr: Restspielzeit CD */
+	ULONG	cdt_AllCompleteBase;	/* Adr: Gesammtspielzeit CD */
+};
+
+/* Ausgangslaustärke des CD-Roms, bei Audio i.d.R. nur Kanal 0 und 1 be-
+   nutzt, Werte von 0-255 möglich */
+
+struct CD_Volume
+{
+	UBYTE	cdv_Chan0;	/* Lautstärke Kanal 0 (0-255) */
+	UBYTE	cdv_Chan1;	/* Lautstärke Kanal 1 (0-255) */
+	UBYTE	cdv_Chan2;	/* Lautstärke Kanal 2 (0-255) */
+	UBYTE	cdv_Chan3;	/* Lautstärke Kanal 3 (0-255) */
+};
+
+/* diverse Infos über Laufwerk */
+
+struct CD_Info
+{
+	BYTE  cdi_DeviceType;		/* Gerätetyp */
+	BOOL  cdi_RemovableMedium;	/* kann Medium entnommen werden? */
+	BYTE  cdi_ANSIVersion;		/* SCSI-Version (0, 1, 2) */
+	UBYTE cdi_VendorID[9];		/* Herstellername */
+	UBYTE cdi_ProductID[17];	/* Product-ID */
+	UBYTE cdi_ProductRev[5];	/* Product-Revision */
+	UBYTE cdi_VendorSpec[21];	/* Vendor-Specification */
+};
+
+/* mögliche Werte der CD_Info Struktur */
+
+/* Device-Type */
+
+#define DIRECT_ACCESS_DEVICE	0	/* z.B. Festplatte */
+#define SEQ_ACCESS_DEVICE	1	/*      Streamer */
+#define PRINTER_DEVICE		2	/*      Drucker */
+#define PROCESSOR_DEVICE	3
+#define WRITE_ONCE_DEVICE	4
+#define CDROM_DEVICE		5	/*      CDRom */
+#define SCANNER_DEVICE		6	/*      Scanner */
+#define OPTICAL_MEMORY_DEVICE	7
+#define MEDIUM_CHANGER_DEVICE	8
+#define COMMUNICATION_DEVICE	9
+
+/* andere Werte sind undefiniert */
+
+/* ANSI/SCSI-Version */
+
+#define UNKNOWN		0
+#define SCSI_1		1
+#define SCSI_2		2
+
+#endif	/* Ende */
+

--- a/oslibs/amigaos/include/proto/cdplayer.h
+++ b/oslibs/amigaos/include/proto/cdplayer.h
@@ -1,0 +1,34 @@
+/* Automatically generated header (sfdc 1.11)! Do not edit! */
+
+#ifndef PROTO_CDPLAYER_H
+#define PROTO_CDPLAYER_H
+
+#include <clib/cdplayer_protos.h>
+
+#ifndef _NO_INLINE
+# if defined(__GNUC__)
+#  ifdef __AROS__
+#   include <defines/cdplayer.h>
+#  else
+#   include <inline/cdplayer.h>
+#  endif
+# else
+#  include <pragmas/cdplayer_pragmas.h>
+# endif
+#endif /* _NO_INLINE */
+
+#ifdef __amigaos4__
+# include <interfaces/cdplayer.h>
+# ifndef __NOGLOBALIFACE__
+   extern struct CDPlayerIFace *ICDPlayer;
+# endif /* __NOGLOBALIFACE__*/
+#endif /* !__amigaos4__ */
+#ifndef __NOLIBBASE__
+  extern struct Library *
+# ifdef __CONSTLIBBASEDECL__
+   __CONSTLIBBASEDECL__
+# endif /* __CONSTLIBBASEDECL__ */
+  CDPlayerBase;
+#endif /* !__NOLIBBASE__ */
+
+#endif /* !PROTO_CDPLAYER_H */


### PR DESCRIPTION
This PR adds CD audio support using cdplayer.library:
https://aminet.net/package/dev/misc/CDPlayerlib37
https://aminet.net/package/util/libs/CDPlayer372p

It should work on MorphOS as well using this version:
http://aminet.net/package/util/libs/cdplayer_lib_ahi
That's currently untested, so I only enabled it for m68k-amigaos in the client makefiles.