### PR TITLE
Some performance improvements

### DIFF
--- a/engine/hexen2/pr_cmds.c
+++ b/engine/hexen2/pr_cmds.c
@@ -1484,24 +1484,34 @@ static void PF_findradius (void)
 	edict_t	*ent, *chain;
 	float	rad;
 	float	*org;
-	vec3_t	eorg;
-	int	i, j;
+	int		i;
 
 	chain = (edict_t *)sv.edicts;
 
 	org = G_VECTOR(OFS_PARM0);
 	rad = G_FLOAT(OFS_PARM1);
+	rad *= rad;
 
 	ent = NEXT_EDICT(sv.edicts);
 	for (i = 1; i < sv.num_edicts; i++, ent = NEXT_EDICT(ent))
 	{
+		float d, lensq;
 		if (ent->free)
 			continue;
 		if (ent->v.solid == SOLID_NOT)
 			continue;
-		for (j = 0; j < 3; j++)
-			eorg[j] = org[j] - (ent->v.origin[j] + (ent->v.mins[j] + ent->v.maxs[j]) * 0.5);
-		if (VectorLength(eorg) > rad)
+
+		d = org[0] - (ent->v.origin[0] + (ent->v.mins[0] + ent->v.maxs[0]) * 0.5);
+		lensq = d * d;
+		if (lensq > rad)
+			continue;
+		d = org[1] - (ent->v.origin[1] + (ent->v.mins[1] + ent->v.maxs[1]) * 0.5);
+		lensq += d * d;
+		if (lensq > rad)
+			continue;
+		d = org[2] - (ent->v.origin[2] + (ent->v.mins[2] + ent->v.maxs[2]) * 0.5);
+		lensq += d * d;
+		if (lensq > rad)
 			continue;
 
 		ent->v.chain = EDICT_TO_PROG(chain);

--- a/engine/hexen2/r_part.c
+++ b/engine/hexen2/r_part.c
@@ -203,7 +203,7 @@ void R_ReadPointFile_f (void)
 	if (cls.state != ca_connected)
 		return; // need an active map.
 
-	color = (byte)Cvar_VariableValue("leak_color");
+	color = (byte)leak_color.integer;
 	q_snprintf (name, sizeof(name), "maps/%s.pts", cl.mapname);
 
 	FS_OpenFile (name, &f, NULL);
@@ -1255,7 +1255,7 @@ void R_SnowEffect (vec3_t org1, vec3_t org2, int flags, vec3_t alldir, int count
 	particle_t	*p;
 	mleaf_t		*l;
 
-	count *= Cvar_VariableValue("snow_active");
+	count *= snow_active.integer;
 	for (i = 0; i < count; i++)
 	{
 		p = AllocParticle();
@@ -1638,7 +1638,7 @@ void R_UpdateParticles (void)
 			// increments of 4 & check solid
 				mleaf_t		*l;
 
-				if (Cvar_VariableValue("snow_flurry") == 1)
+				if (snow_flurry.integer == 1)
 				{
 				    if (rand() & 31)
 				    {

--- a/engine/hexenworld/server/pr_cmds.c
+++ b/engine/hexenworld/server/pr_cmds.c
@@ -1333,24 +1333,34 @@ static void PF_findradius (void)
 	edict_t	*ent, *chain;
 	float	rad;
 	float	*org;
-	vec3_t	eorg;
-	int	i, j;
+	int		i;
 
 	chain = (edict_t *)sv.edicts;
 
 	org = G_VECTOR(OFS_PARM0);
 	rad = G_FLOAT(OFS_PARM1);
+	rad *= rad;
 
 	ent = NEXT_EDICT(sv.edicts);
 	for (i = 1; i < sv.num_edicts; i++, ent = NEXT_EDICT(ent))
 	{
+		float d, lensq;
 		if (ent->free)
 			continue;
 		if (ent->v.solid == SOLID_NOT)
 			continue;
-		for (j = 0; j < 3; j++)
-			eorg[j] = org[j] - (ent->v.origin[j] + (ent->v.mins[j] + ent->v.maxs[j]) * 0.5);
-		if (VectorLength(eorg) > rad)
+
+		d = org[0] - (ent->v.origin[0] + (ent->v.mins[0] + ent->v.maxs[0]) * 0.5);
+		lensq = d * d;
+		if (lensq > rad)
+			continue;
+		d = org[1] - (ent->v.origin[1] + (ent->v.mins[1] + ent->v.maxs[1]) * 0.5);
+		lensq += d * d;
+		if (lensq > rad)
+			continue;
+		d = org[2] - (ent->v.origin[2] + (ent->v.mins[2] + ent->v.maxs[2]) * 0.5);
+		lensq += d * d;
+		if (lensq > rad)
 			continue;
 
 		ent->v.chain = EDICT_TO_PROG(chain);


### PR DESCRIPTION
When looking at the particles I noticed that the snow used Cvar_VariableValue instead of the actual variables which caused a small performance drop in the Tibet levels of the mission pack.
I also applied the this unrelated tweak to PF_findradius which avoids calculating the square root: https://github.com/sezero/quakespasm/commit/a1f522701a7969d2f9df77bd94a14527398bfd53. I left the original code there commented out just in case it causes any side effects, but so far I haven't noticed any.