### PR TITLE
Amiga: further improved translucent performance

### DIFF
--- a/engine/h2shared/d_part68k.s
+++ b/engine/h2shared/d_part68k.s
@@ -245,11 +245,9 @@ _D_DrawParticle
 		lea     0(a0,d2.l*2),a0         ;pz += d_zwidth
 		dbra    d0,.more_loop
 .is_trans
-		add.l   #-256,d4
-		lsl.l   #8,d4              ; << 8 for transTable idx
+		add.w   #-256,d4
+		lsl.w   #8,d4                   ; << 8 for transTable idx
 		move.l  _transTable,a4
-		add.l   d4,a4
-		clr.l   d4
 		cmp.l   #4,d0                   ;switch (pix)
 		bgt.b   .t_more
 		beq.b   .t_four


### PR DESCRIPTION
I rewrote most of D_DrawTurbulent8T to get rid of the remnants of D_DrawSingleZSpans, and properly merge its functionality. This allowed to reuse a lot of already calculated values, and to remove the double z-buffer checks when a model is occluding the surface. 
D_DrawParticle also received a small improvement, the offset for the translucency table index is now calculated the same way as the other functions with only two additional instructions.