### PR TITLE
amiga: 68k optimized alias functions

### DIFF
--- a/engine/h2shared/r_aclip.c
+++ b/engine/h2shared/r_aclip.c
@@ -27,7 +27,7 @@
 static finalvert_t		fv[2][8];
 static auxvert_t		av[8];
 
-#if !id386
+#if !id386 && !id68k
 static void R_Alias_clip_top (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out);
 static void R_Alias_clip_bottom (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out);
 static void R_Alias_clip_left (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out);
@@ -88,7 +88,7 @@ static void R_Alias_clip_z (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *o
 }
 
 
-#if	!id386
+#if	!id386 && !id68k
 
 static void R_Alias_clip_left (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out)
 {

--- a/engine/h2shared/r_aclip68k.s
+++ b/engine/h2shared/r_aclip68k.s
@@ -1,0 +1,417 @@
+**
+** Quake for AMIGA
+** r_aclip.c assembler implementations by Frank Wille <frank@phoenix.owl.de>
+**
+
+		;INCLUDE	"quakedef68k.i"
+REFDEF_ALIASVRECT	equ	20
+REFDEF_ALIASVRECTRIGHT	equ	48
+REFDEF_ALIASVRECTBOTTOM	equ	52
+VRECT_X	equ	0
+VRECT_Y	equ	4
+
+		XREF    _r_refdef
+
+		XDEF    _R_Alias_clip_left
+		XDEF    _R_Alias_clip_right
+		XDEF    _R_Alias_clip_top
+		XDEF    _R_Alias_clip_bottom
+
+ALIAS_LEFT_CLIP         =       1
+ALIAS_TOP_CLIP          =       2
+ALIAS_RIGHT_CLIP        =       4
+ALIAS_BOTTOM_CLIP       =       8
+
+
+
+		fpu
+
+******************************************************************************
+*
+*       void _R_Alias_clip_left (finalvert_t *pfv0, finalvert_t *pfv1,
+*                                finalvert_t *out)
+*
+******************************************************************************
+
+		cnop    0,4
+_R_Alias_clip_left
+
+*****   stackframe
+
+		rsreset
+.fpuregs        rs.x    2
+.intregs        rs.l    5
+		rs.l    1
+.pfv0           rs.l    1
+.pfv1           rs.l    1
+.out            rs.l    1
+
+
+		movem.l d2-d4/a2/a3,-(sp)
+		fmovem.x        fp2/fp3,-(sp)
+		move.l  .pfv0(sp),a0
+		move.l  .pfv1(sp),a1
+		move.l  .out(sp),a2
+		lea     _r_refdef,a3
+		fmove.s #0.5,fp2
+		move.l  (a0)+,d2
+		move.l  (a0)+,d3
+		move.l  (a1)+,d0
+		move.l  (a1)+,d1
+		move.l  REFDEF_ALIASVRECT+VRECT_X(a3),d4
+		cmp.l   d1,d3
+		blt.b   .cont
+		sub.l   d2,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d0,d4
+		sub.l   d2,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d0
+		add.l   d2,d0
+		move.l  d0,(a2)+
+		moveq   #5-1,d2
+		bra.b   .entry
+.loop
+		move.l  (a0)+,d3
+		move.l  (a1)+,d1
+.entry
+		sub.l   d3,d1
+		fmove.l d1,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d1
+		add.l   d3,d1
+		move.l  d1,(a2)+
+		dbra    d2,.loop
+		bra.b   .exit
+.cont
+		sub.l   d0,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d2,d4
+		sub.l   d0,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d2
+		add.l   d0,d2
+		move.l  d2,(a2)+
+		moveq   #5-1,d2
+		bra.b   .entry2
+.loop2
+		move.l  (a0)+,d3
+		move.l  (a1)+,d1
+.entry2
+		sub.l   d1,d3
+		fmove.l d3,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d3
+		add.l   d1,d3
+		move.l  d3,(a2)+
+		dbra    d2,.loop2
+.exit
+		fmovem.x        (sp)+,fp2/fp3
+		movem.l (sp)+,d2-d4/a2/a3
+		rts
+
+
+
+
+
+
+******************************************************************************
+*
+*       void _R_Alias_clip_right (finalvert_t *pfv0, finalvert_t *pfv1,
+*                                 finalvert_t *out)
+*
+******************************************************************************
+
+		cnop    0,4
+_R_Alias_clip_right
+
+*****   stackframe
+
+		rsreset
+.fpuregs        rs.x    2
+.intregs        rs.l    5
+		rs.l    1
+.pfv0           rs.l    1
+.pfv1           rs.l    1
+.out            rs.l    1
+
+
+		movem.l d2-d4/a2/a3,-(sp)
+		fmovem.x        fp2/fp3,-(sp)
+		move.l  .pfv0(sp),a0
+		move.l  .pfv1(sp),a1
+		move.l  .out(sp),a2
+		lea     _r_refdef,a3
+		fmove.s #0.5,fp2
+		move.l  (a0)+,d2
+		move.l  (a0)+,d3
+		move.l  (a1)+,d0
+		move.l  (a1)+,d1
+		move.l  REFDEF_ALIASVRECTRIGHT(a3),d4
+		cmp.l   d1,d3
+		blt.b   .cont
+		sub.l   d2,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d0,d4
+		sub.l   d2,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d0
+		add.l   d2,d0
+		move.l  d0,(a2)+
+		moveq   #5-1,d2
+		bra.b   .entry
+.loop
+		move.l  (a0)+,d3
+		move.l  (a1)+,d1
+.entry
+		sub.l   d3,d1
+		fmove.l d1,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d1
+		add.l   d3,d1
+		move.l  d1,(a2)+
+		dbra    d2,.loop
+		bra.b   .exit
+.cont
+		sub.l   d0,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d2,d4
+		sub.l   d0,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d2
+		add.l   d0,d2
+		move.l  d2,(a2)+
+		moveq   #5-1,d2
+		bra.b   .entry2
+.loop2
+		move.l  (a0)+,d3
+		move.l  (a1)+,d1
+.entry2
+		sub.l   d1,d3
+		fmove.l d3,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d3
+		add.l   d1,d3
+		move.l  d3,(a2)+
+		dbra    d2,.loop2
+.exit
+		fmovem.x        (sp)+,fp2/fp3
+		movem.l (sp)+,d2-d4/a2/a3
+		rts
+
+
+
+
+
+
+
+******************************************************************************
+*
+*       void _R_Alias_clip_top (finalvert_t *pfv0, finalvert_t *pfv1,
+*                               finalvert_t *out)
+*
+******************************************************************************
+
+		cnop    0,4
+_R_Alias_clip_top
+
+*****   stackframe
+
+		rsreset
+.fpuregs        rs.x    2
+.intregs        rs.l    5
+		rs.l    1
+.pfv0           rs.l    1
+.pfv1           rs.l    1
+.out            rs.l    1
+
+
+		movem.l d2-d4/a2/a3,-(sp)
+		fmovem.x        fp2/fp3,-(sp)
+		move.l  .pfv0(sp),a0
+		move.l  .pfv1(sp),a1
+		move.l  .out(sp),a2
+		lea     _r_refdef,a3
+		fmove.s #0.5,fp2
+		move.l  (a0)+,d2
+		move.l  (a0)+,d3
+		move.l  (a1)+,d0
+		move.l  (a1)+,d1
+		move.l  REFDEF_ALIASVRECT+VRECT_Y(a3),d4
+		cmp.l   d1,d3
+		blt.b   .cont
+		sub.l   d3,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d1,d4
+		sub.l   d3,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d1
+		add.l   d3,d1
+		move.l  d1,(a2)+
+		moveq   #5-1,d3
+		bra.b   .entry
+.loop
+		move.l  (a0)+,d2
+		move.l  (a1)+,d0
+.entry
+		sub.l   d2,d0
+		fmove.l d0,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d0
+		add.l   d2,d0
+		move.l  d0,(a2)+
+		dbra    d3,.loop
+		bra.b   .exit
+.cont
+		sub.l   d1,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d3,d4
+		sub.l   d1,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d3
+		add.l   d1,d3
+		move.l  d3,(a2)+
+		moveq   #5-1,d3
+		bra.b   .entry2
+.loop2
+		move.l  (a0)+,d2
+		move.l  (a1)+,d0
+.entry2
+		sub.l   d0,d2
+		fmove.l d2,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d2
+		add.l   d0,d2
+		move.l  d2,(a2)+
+		dbra    d3,.loop2
+.exit
+		move.l  -24(a2),d0
+		move.l  -20(a2),-24(a2)
+		move.l  d0,-20(a2)
+		fmovem.x        (sp)+,fp2/fp3
+		movem.l (sp)+,d2-d4/a2/a3
+		rts
+
+
+
+
+
+
+******************************************************************************
+*
+*       void _R_Alias_clip_bottom (finalvert_t *pfv0, finalvert_t *pfv1,
+*                                  finalvert_t *out)
+*
+******************************************************************************
+
+		cnop    0,4
+_R_Alias_clip_bottom
+
+*****   stackframe
+
+		rsreset
+.fpuregs        rs.x    2
+.intregs        rs.l    5
+		rs.l    1
+.pfv0           rs.l    1
+.pfv1           rs.l    1
+.out            rs.l    1
+
+
+		movem.l d2-d4/a2/a3,-(sp)
+		fmovem.x        fp2/fp3,-(sp)
+		move.l  .pfv0(sp),a0
+		move.l  .pfv1(sp),a1
+		move.l  .out(sp),a2
+		lea     _r_refdef,a3
+		fmove.s #0.5,fp2
+		move.l  (a0)+,d2
+		move.l  (a0)+,d3
+		move.l  (a1)+,d0
+		move.l  (a1)+,d1
+		move.l  REFDEF_ALIASVRECTBOTTOM(a3),d4
+		cmp.l   d1,d3
+		blt.b   .cont
+		sub.l   d3,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d1,d4
+		sub.l   d3,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d1
+		add.l   d3,d1
+		move.l  d1,(a2)+
+		moveq   #5-1,d3
+		bra.b   .entry
+.loop
+		move.l  (a0)+,d2
+		move.l  (a1)+,d0
+.entry
+		sub.l   d2,d0
+		fmove.l d0,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d0
+		add.l   d2,d0
+		move.l  d0,(a2)+
+		dbra    d3,.loop
+		bra.b   .exit
+.cont
+		sub.l   d1,d4
+		fmove.l d4,fp0
+		fmove   fp0,fp3
+		fadd    fp2,fp3
+		move.l  d3,d4
+		sub.l   d1,d4
+		fmove.l d4,fp1
+		fdiv    fp1,fp0
+		fmove.l fp3,d3
+		add.l   d1,d3
+		move.l  d3,(a2)+
+		moveq   #5-1,d3
+		bra.b   .entry2
+.loop2
+		move.l  (a0)+,d2
+		move.l  (a1)+,d0
+.entry2
+		sub.l   d0,d2
+		fmove.l d2,fp1
+		fmul    fp0,fp1
+		fadd    fp2,fp1
+		fmove.l fp1,d2
+		add.l   d0,d2
+		move.l  d2,(a2)+
+		dbra    d3,.loop2
+.exit
+		move.l  -24(a2),d0
+		move.l  -20(a2),-24(a2)
+		move.l  d0,-20(a2)
+		fmovem.x        (sp)+,fp2/fp3
+		movem.l (sp)+,d2-d4/a2/a3
+		rts

--- a/engine/h2shared/r_alias68k.s
+++ b/engine/h2shared/r_alias68k.s
@@ -1,0 +1,217 @@
+**
+** Quake for AMIGA
+** r_alias.c assembler implementations by Frank Wille <frank@phoenix.owl.de>
+**
+
+		;INCLUDE	"quakedef68k.i"
+FV_FLAGS	equ	24
+TV_LIGHTNORMALINDEX	equ	3
+SV_ONSEAM	equ	0
+SV_S	equ	4
+SV_T	equ	8
+
+		XREF    _aliastransform
+		XREF    _r_avertexnormals
+		XREF    _r_plightvec
+		XREF    _r_ambientlight
+		XREF    _r_shadelight
+		XREF    _ziscale
+		;XREF    _aliasxscale
+		;XREF    _aliasyscale
+		;XREF    _aliasxcenter
+		;XREF    _aliasycenter
+
+		XDEF    _R_AliasTransformVector
+		XDEF    _R_AliasTransformFinalVert
+
+
+
+		fpu
+
+******************************************************************************
+*
+*       void _R_AliasTransformVector (vec3_t in, vec3_t out)
+*
+******************************************************************************
+
+		cnop    0,4
+_R_AliasTransformVector
+
+*****   stackframe
+
+		rsreset
+.fpuregs        rs.x    4
+		rs.l    1
+.in             rs.l    1
+.out            rs.l    1
+
+		fmovem.x        fp2-fp5,-(sp)
+		move.l  .in(sp),a0
+		move.l  .out(sp),a1
+		fmove.s (a0)+,fp0
+		fmove.s (a0)+,fp1
+		fmove.s (a0)+,fp2
+		lea     _aliastransform,a0
+		fmove.s (a0)+,fp3
+		fmul    fp0,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp1,fp4
+		fadd    fp4,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp2,fp4
+		fadd    fp4,fp3
+		fadd.s  (a0)+,fp3
+		fmove.s fp3,(a1)+
+		fmove.s (a0)+,fp3
+		fmul    fp0,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp1,fp4
+		fadd    fp4,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp2,fp4
+		fadd    fp4,fp3
+		fadd.s  (a0)+,fp3
+		fmove.s fp3,(a1)+
+		fmul.s  (a0)+,fp0
+		fmul.s  (a0)+,fp1
+		fadd    fp1,fp0
+		fmul.s  (a0)+,fp2
+		fadd    fp2,fp0
+		fadd.s  (a0)+,fp0
+		fmove.s fp0,(a1)+
+		fmovem.x        (sp)+,fp2-fp5
+		rts
+
+
+
+
+
+
+******************************************************************************
+*
+*       void _R_AliasTransformFinalVert (finalvert_t *fv, auxvert_t *av,
+*                                      trivertx_t *pverts, stvert_t *pstverts)
+*
+******************************************************************************
+
+		cnop    0,4
+_R_AliasTransformFinalVert
+
+*****   stackframe
+
+		rsreset
+.fpuregs        rs.x    3
+.intregs        rs.l    1
+		rs.l    1
+.fv             rs.l    1
+.av             rs.l    1
+.tv             rs.l    1
+.sv             rs.l    1
+
+
+		move.l  a2,-(sp)
+		fmovem.x        fp2-fp4,-(sp)
+		move.l  .av(sp),a1
+		move.l  .tv(sp),a2
+
+*        av->fv[0] = DotProduct(pverts->v, aliastransform[0]) +
+*                        aliastransform[0][3];
+*        av->fv[1] = DotProduct(pverts->v, aliastransform[1]) +
+*                        aliastransform[1][3];
+*        av->fv[2] = DotProduct(pverts->v, aliastransform[2]) +
+*                        aliastransform[2][3];
+
+		lea     _aliastransform,a0
+		moveq   #0,d0
+		move.b  (a2),d0
+		fmove.l d0,fp0
+		move.b  1(a2),d0
+		fmove.l d0,fp1
+		move.b  2(a2),d0
+		fmove.l d0,fp2
+		fmove.s (a0)+,fp3
+		fmul    fp0,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp1,fp4
+		fadd    fp4,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp2,fp4
+		fadd    fp4,fp3
+		fadd.s  (a0)+,fp3
+		fmove.s fp3,(a1)+
+		fmove.s (a0)+,fp3
+		fmul    fp0,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp1,fp4
+		fadd    fp4,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp2,fp4
+		fadd    fp4,fp3
+		fadd.s  (a0)+,fp3
+		fmove.s fp3,(a1)+
+		fmove.s (a0)+,fp3
+		fmul    fp0,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp1,fp4
+		fadd    fp4,fp3
+		fmove.s (a0)+,fp4
+		fmul    fp2,fp4
+		fadd    fp4,fp3
+		fadd.s  (a0)+,fp3
+		fmove.s fp3,(a1)+
+
+*        fv->v[2] = pstverts->s;
+*        fv->v[3] = pstverts->t;
+*
+*        fv->flags = pstverts->onseam;
+
+		move.l  .fv(sp),a0
+		move.l  .sv(sp),a1
+		move.l  SV_S(a1),8(a0)
+		move.l  SV_T(a1),12(a0)
+		move.l  SV_ONSEAM(a1),FV_FLAGS(a0)
+
+*        plightnormal = r_avertexnormals[pverts->lightnormalindex];
+*        lightcos = DotProduct (plightnormal, r_plightvec);
+*        temp = r_ambientlight;
+
+		lea     _r_avertexnormals,a1
+		moveq   #0,d0
+		move.b  TV_LIGHTNORMALINDEX(a2),d0
+		muls    #12,d0
+		add.l   d0,a1
+		lea     _r_plightvec,a2
+		fmove.s (a2)+,fp0
+		fmove.s (a2)+,fp1
+		fmove.s (a2)+,fp2
+		fmul.s  (a1)+,fp0
+		fmul.s  (a1)+,fp1
+		fadd    fp1,fp0
+		fmul.s  (a1)+,fp2
+		fadd    fp2,fp0
+		move.l  _r_ambientlight,d0
+
+*        if (lightcos < 0)
+*        {
+*                temp += (int)(r_shadelight * lightcos);
+*
+*        // clamp; because we limited the minimum ambient and shading light, we
+*        // don't have to clamp low light, just bright
+*                if (temp < 0)
+*                        temp = 0;
+*        }
+*
+*        fv->v[4] = temp;
+
+		ftst    fp0
+		fboge.w .cont
+		fmul.s  _r_shadelight,fp0
+		fmove.l fp0,d1
+		add.l   d1,d0
+		bge.b   .cont
+		moveq   #0,d0
+.cont
+		move.l  d0,16(a0)
+		fmovem.x        (sp)+,fp2-fp4
+		move.l  (sp)+,a2
+		rts

--- a/engine/h2shared/r_local.h
+++ b/engine/h2shared/r_local.h
@@ -222,6 +222,9 @@ void R_Alias_clip_right (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out)
 void R_AliasTransformAndProjectFinalVerts (finalvert_t *fv, stvert_t *pstverts);
 
 void R_ClipEdge (mvertex_t *pv0, mvertex_t *pv1, clipplane_t *clip);
+
+void R_AliasTransformVector (vec3_t in, vec3_t out);
+void R_AliasTransformFinalVert (finalvert_t *fv, auxvert_t *av, trivertx_t *pverts);
 #endif
 
 ASM_LINKAGE_END

--- a/engine/h2shared/r_local.h
+++ b/engine/h2shared/r_local.h
@@ -214,6 +214,11 @@ void R_InsertNewEdges (edge_t *edgestoadd, edge_t *edgelist);
 void R_RemoveEdges (edge_t *pedge);
 void R_StepActiveU (edge_t *pedge);
 
+void R_Alias_clip_top (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out);
+void R_Alias_clip_bottom (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out);
+void R_Alias_clip_left (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out);
+void R_Alias_clip_right (finalvert_t *pfv0, finalvert_t *pfv1, finalvert_t *out);
+
 void R_AliasTransformAndProjectFinalVerts (finalvert_t *fv, stvert_t *pstverts);
 
 void R_ClipEdge (mvertex_t *pv0, mvertex_t *pv1, clipplane_t *clip);

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -1295,6 +1295,7 @@ SOFT_ASM = \
 	d_scan68k.o \
 	d_sky68k.o \
 	d_sprite68k.o \
+	r_aclip68k.o \
 	r_edge68k.o \
 	r_sky68k.o \
 	r_surf68k.o

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -1296,6 +1296,7 @@ SOFT_ASM = \
 	d_sky68k.o \
 	d_sprite68k.o \
 	r_aclip68k.o \
+	r_alias68k.o \
 	r_edge68k.o \
 	r_sky68k.o \
 	r_surf68k.o

--- a/engine/hexen2/r_alias.c
+++ b/engine/hexen2/r_alias.c
@@ -81,8 +81,10 @@ static aedge_t	aedges[12] =
 static void R_AliasTransformAndProjectFinalVerts (finalvert_t *fv, stvert_t *pstverts);
 #endif
 static void R_AliasSetUpTransform (int trivial_accept);
+#if !id68k
 static void R_AliasTransformVector (vec3_t in, vec3_t out);
 static void R_AliasTransformFinalVert (finalvert_t *fv, auxvert_t *av, trivertx_t *pverts);
+#endif
 
 
 /*
@@ -267,6 +269,7 @@ qboolean R_AliasCheckBBox (void)
 }
 
 
+#if !id68k
 /*
 ================
 R_AliasTransformVector
@@ -278,6 +281,7 @@ static void R_AliasTransformVector (vec3_t in, vec3_t out)
 	out[1] = DotProduct(in, aliastransform[1]) + aliastransform[1][3];
 	out[2] = DotProduct(in, aliastransform[2]) + aliastransform[2][3];
 }
+#endif
 
 
 /*
@@ -553,6 +557,7 @@ static void R_AliasSetUpTransform (int trivial_accept)
 }
 
 
+#if !id68k
 /*
 ================
 R_AliasTransformFinalVert
@@ -584,6 +589,7 @@ static void R_AliasTransformFinalVert (finalvert_t *fv, auxvert_t *av, trivertx_
 
 	fv->v[4] = temp;
 }
+#endif
 
 
 #if	!id386 && !id68k

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -1261,6 +1261,7 @@ SOFT_ASM = \
 	d_scan68k.o \
 	d_sky68k.o \
 	d_sprite68k.o \
+	r_aclip68k.o \
 	r_edge68k.o \
 	r_sky68k.o \
 	r_surf68k.o

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -1262,6 +1262,7 @@ SOFT_ASM = \
 	d_sky68k.o \
 	d_sprite68k.o \
 	r_aclip68k.o \
+	r_alias68k.o \
 	r_edge68k.o \
 	r_sky68k.o \
 	r_surf68k.o


### PR DESCRIPTION
Added R_Alias_clip_left, R_Alias_clip_right, R_Alias_clip_top and R_Alias_clip_bottom asm implementations. R_Alias_clip_left and R_Alias_clip_top has a small issue where they clip most polygons 1 pixel too early, leaving a seam at the edge of the screen. It's not very noticeable except with large models. The Quake port I use as a base has the same issue, but it's even less noticeable due to everything being brown. There's probably a rounding error somewhere, but I couldn't see any obvious problems. I'll look into it later.
I also ported over R_AliasTransformVector and R_AliasTransformFinalVert that have slightly better implementation than the compiler output.