### PR TITLE
added an interleaved sin/cos table for refresh functions

### DIFF
--- a/engine/h2shared/r_bsp.c
+++ b/engine/h2shared/r_bsp.c
@@ -85,6 +85,7 @@ R_RotateBmodel
 void R_RotateBmodel (void)
 {
 	float	angle, s, c, temp1[3][3], temp2[3][3], temp3[3][3];
+	float	*psincos;
 
 // TODO: should use a look-up table
 // TODO: should really be stored with the entity instead of being reconstructed
@@ -93,9 +94,12 @@ void R_RotateBmodel (void)
 
 // yaw
 	angle = currententity->angles[YAW];
-	angle = angle * M_PI*2 / 360;
-	s = sin(angle);
-	c = cos(angle);
+	//angle = angle * M_PI*2 / 360;
+	//s = sin(angle);
+	//c = cos(angle);
+	psincos = &r_sincos[SINCOS_INDEX(angle)];
+	s = *psincos++;
+	c = *psincos;
 
 	temp1[0][0] = c;
 	temp1[0][1] = s;
@@ -109,9 +113,12 @@ void R_RotateBmodel (void)
 
 // pitch
 	angle = currententity->angles[PITCH];
-	angle = angle * M_PI*2 / 360;
-	s = sin(angle);
-	c = cos(angle);
+	//angle = angle * M_PI*2 / 360;
+	//s = sin(angle);
+	//c = cos(angle);
+	psincos = &r_sincos[SINCOS_INDEX(angle)];
+	s = *psincos++;
+	c = *psincos;
 
 	temp2[0][0] = c;
 	temp2[0][1] = 0;
@@ -127,9 +134,12 @@ void R_RotateBmodel (void)
 
 // roll
 	angle = currententity->angles[ROLL];
-	angle = angle * M_PI*2 / 360;
-	s = sin(angle);
-	c = cos(angle);
+	//angle = angle * M_PI*2 / 360;
+	//s = sin(angle);
+	//c = cos(angle);
+	psincos = &r_sincos[SINCOS_INDEX(angle)];
+	s = *psincos++;
+	c = *psincos;
 
 	temp1[0][0] = 1;
 	temp1[0][1] = 0;

--- a/engine/h2shared/r_draw.c
+++ b/engine/h2shared/r_draw.c
@@ -42,6 +42,8 @@ clipplane_t	world_clipplanes[16];
 int		sintable[SIN_BUFFER_SIZE];
 int		intsintable[SIN_BUFFER_SIZE];
 
+float		r_sincos[SINCOS_SIZE];
+
 ASM_LINKAGE_BEGIN
 unsigned int	cacheoffset;
 

--- a/engine/h2shared/r_shared.h
+++ b/engine/h2shared/r_shared.h
@@ -66,6 +66,11 @@ extern	cvar_t	r_clearcolor;
 extern	int	sintable[SIN_BUFFER_SIZE];
 extern	int	intsintable[SIN_BUFFER_SIZE];
 
+#define SINCOS_RES 8
+#define SINCOS_SIZE (360*SINCOS_RES*2)
+#define SINCOS_INDEX(angle) ((int)((angle) * SINCOS_RES) * 2)
+extern	float	r_sincos[SINCOS_SIZE];
+
 extern	vec3_t	vup, base_vup;
 extern	vec3_t	vpn, base_vpn;
 extern	vec3_t	vright, base_vright;

--- a/engine/h2shared/r_shared.h
+++ b/engine/h2shared/r_shared.h
@@ -66,9 +66,9 @@ extern	cvar_t	r_clearcolor;
 extern	int	sintable[SIN_BUFFER_SIZE];
 extern	int	intsintable[SIN_BUFFER_SIZE];
 
-#define SINCOS_RES 8
-#define SINCOS_SIZE (360*SINCOS_RES*2)
-#define SINCOS_INDEX(angle) ((int)((angle) * SINCOS_RES) * 2)
+#define SINCOS_ANGLES 2048
+#define SINCOS_SIZE (SINCOS_ANGLES*2)
+#define SINCOS_INDEX(angle) (((int)((angle) * (1.0f/360.f) * SINCOS_ANGLES) & (SINCOS_ANGLES-1)) * 2)
 extern	float	r_sincos[SINCOS_SIZE];
 
 extern	vec3_t	vup, base_vup;

--- a/engine/h2shared/r_sprite.c
+++ b/engine/h2shared/r_sprite.c
@@ -288,6 +288,7 @@ void R_DrawSprite (void)
 	msprite_t	*psprite;
 	vec3_t		tvec;
 	float		dot, angle, sr, cr;
+	float		*psincos;
 
 	psprite = (msprite_t *) currententity->model->cache.data;
 
@@ -377,9 +378,13 @@ void R_DrawSprite (void)
 	// generate the sprite's axes, parallel to the viewplane, but rotated in
 	// that plane around the center according to the sprite entity's roll
 	// angle. So vpn stays the same, but vright and vup rotate
-		angle = currententity->angles[ROLL] * (M_PI*2 / 360);
-		sr = sin(angle);
-		cr = cos(angle);
+		//angle = currententity->angles[ROLL] * (M_PI*2 / 360);
+		//sr = sin(angle);
+		//cr = cos(angle);
+		angle = currententity->angles[ROLL];
+		psincos = &r_sincos[SINCOS_INDEX(angle)];
+		sr = *psincos++;
+		cr = *psincos;
 
 		for (i = 0 ; i < 3 ; i++)
 		{

--- a/engine/hexen2/r_main.c
+++ b/engine/hexen2/r_main.c
@@ -226,6 +226,22 @@ static void R_InitTurb (void)
 }
 
 /*
+================
+R_InitSinCos
+================
+*/
+static void R_InitSinCos (void)
+{
+	int		i;
+
+	for (i = 0 ; i < (SINCOS_SIZE/2) ; i++)
+	{
+		r_sincos[i*2 + 0] = sin(i * M_PI*2 / 360 / SINCOS_RES);
+		r_sincos[i*2 + 1] = cos(i * M_PI*2 / 360 / SINCOS_RES);
+	}
+}
+
+/*
 ===============
 R_Init
 ===============
@@ -238,6 +254,7 @@ void R_Init (void)
 	r_stack_start = (byte *)&dummy;
 
 	R_InitTurb ();
+	R_InitSinCos ();
 
 	Cmd_AddCommand ("timerefresh", R_TimeRefresh_f);
 	Cmd_AddCommand ("pointfile", R_ReadPointFile_f);

--- a/engine/hexen2/r_main.c
+++ b/engine/hexen2/r_main.c
@@ -234,10 +234,10 @@ static void R_InitSinCos (void)
 {
 	int		i;
 
-	for (i = 0 ; i < (SINCOS_SIZE/2) ; i++)
+	for (i = 0 ; i < (SINCOS_ANGLES) ; i++)
 	{
-		r_sincos[i*2 + 0] = sin(i * M_PI*2 / 360 / SINCOS_RES);
-		r_sincos[i*2 + 1] = cos(i * M_PI*2 / 360 / SINCOS_RES);
+		r_sincos[i*2 + 0] = sin(i * M_PI*2 / SINCOS_ANGLES);
+		r_sincos[i*2 + 1] = cos(i * M_PI*2 / SINCOS_ANGLES);
 	}
 }
 

--- a/engine/hexenworld/client/r_main.c
+++ b/engine/hexenworld/client/r_main.c
@@ -232,6 +232,20 @@ static void R_InitTurb (void)
 }
 
 /*
+================
+R_InitSinCos
+================
+*/
+static void R_InitSinCos (void)
+{
+	for (i = 0 ; i < (SINCOS_SIZE/2) ; i++)
+	{
+		r_sincos[i*2 + 0] = sin(i * M_PI*2 / 360 / SINCOS_RES);
+		r_sincos[i*2 + 1] = cos(i * M_PI*2 / 360 / SINCOS_RES);
+	}
+}
+
+/*
 ===============
 R_Init
 ===============
@@ -244,6 +258,7 @@ void R_Init (void)
 	r_stack_start = (byte *)&dummy;
 
 	R_InitTurb ();
+	R_InitSinCos ();
 
 	Cmd_AddCommand ("timerefresh", R_TimeRefresh_f);
 	Cmd_AddCommand ("pointfile", R_ReadPointFile_f);

--- a/engine/hexenworld/client/r_main.c
+++ b/engine/hexenworld/client/r_main.c
@@ -238,10 +238,12 @@ R_InitSinCos
 */
 static void R_InitSinCos (void)
 {
-	for (i = 0 ; i < (SINCOS_SIZE/2) ; i++)
+	int		i;
+
+	for (i = 0 ; i < (SINCOS_ANGLES) ; i++)
 	{
-		r_sincos[i*2 + 0] = sin(i * M_PI*2 / 360 / SINCOS_RES);
-		r_sincos[i*2 + 1] = cos(i * M_PI*2 / 360 / SINCOS_RES);
+		r_sincos[i*2 + 0] = sin(i * M_PI*2 / SINCOS_ANGLES);
+		r_sincos[i*2 + 1] = cos(i * M_PI*2 / SINCOS_ANGLES);
 	}
 }
 


### PR DESCRIPTION
This started out as an attempt to replace R_RotateBmodel with the assembly version. In the end that wasn't feasible as it accessed currententity, but I took the idea of using an interleaved sin/cos table in that function. I put it into R_DrawSprite for the SPR_VP_PARALLEL_ORIENTED too. It could also be used in CL_UpdateEffects for various particle effects, but cl_effect.c doesn't include r_shared.h. I'm not sure what would be a good place to include it.