### PR TITLE
Amiga stability improvements

### DIFF
--- a/engine/h2shared/d_edge.c
+++ b/engine/h2shared/d_edge.c
@@ -30,7 +30,7 @@ int		vstartscan;
 
 // FIXME: should go away
 extern void	R_RotateBmodel (void);
-extern void	R_TransformFrustum (void);
+//extern void	R_TransformFrustum (void);
 
 vec3_t		transformed_modelorg;
 

--- a/engine/h2shared/d_edge.c
+++ b/engine/h2shared/d_edge.c
@@ -30,7 +30,6 @@ int		vstartscan;
 
 // FIXME: should go away
 extern void	R_RotateBmodel (void);
-//extern void	R_TransformFrustum (void);
 
 vec3_t		transformed_modelorg;
 

--- a/engine/h2shared/r_alias68k.s
+++ b/engine/h2shared/r_alias68k.s
@@ -1,14 +1,15 @@
 **
 ** Quake for AMIGA
 ** r_alias.c assembler implementations by Frank Wille <frank@phoenix.owl.de>
+** Adapted for Hexen II by Szilard Biro
 **
 
 		;INCLUDE	"quakedef68k.i"
-FV_FLAGS	equ	24
+;FV_FLAGS	equ	24
 TV_LIGHTNORMALINDEX	equ	3
-SV_ONSEAM	equ	0
-SV_S	equ	4
-SV_T	equ	8
+;SV_ONSEAM	equ	0
+;SV_S	equ	4
+;SV_T	equ	8
 
 		XREF    _aliastransform
 		XREF    _r_avertexnormals
@@ -90,7 +91,7 @@ _R_AliasTransformVector
 ******************************************************************************
 *
 *       void _R_AliasTransformFinalVert (finalvert_t *fv, auxvert_t *av,
-*                                      trivertx_t *pverts, stvert_t *pstverts)
+*                                      trivertx_t *pverts)
 *
 ******************************************************************************
 
@@ -106,7 +107,7 @@ _R_AliasTransformFinalVert
 .fv             rs.l    1
 .av             rs.l    1
 .tv             rs.l    1
-.sv             rs.l    1
+;.sv             rs.l    1
 
 
 		move.l  a2,-(sp)
@@ -166,10 +167,10 @@ _R_AliasTransformFinalVert
 *        fv->flags = pstverts->onseam;
 
 		move.l  .fv(sp),a0
-		move.l  .sv(sp),a1
-		move.l  SV_S(a1),8(a0)
-		move.l  SV_T(a1),12(a0)
-		move.l  SV_ONSEAM(a1),FV_FLAGS(a0)
+		;move.l  .sv(sp),a1
+		;move.l  SV_S(a1),8(a0)
+		;move.l  SV_T(a1),12(a0)
+		;move.l  SV_ONSEAM(a1),FV_FLAGS(a0)
 
 *        plightnormal = r_avertexnormals[pverts->lightnormalindex];
 *        lightcos = DotProduct (plightnormal, r_plightvec);

--- a/engine/h2shared/r_bsp68k.s
+++ b/engine/h2shared/r_bsp68k.s
@@ -1,0 +1,90 @@
+**
+** Quake for AMIGA
+** r_bsp.c assembler implementations by Frank Wille <frank@phoenix.owl.de>
+** Adapted for Hexen II by Szilard Biro
+**
+
+		;INCLUDE	"quakedef68k.i"
+CLIP_SIZEOF	equ	24
+MPLANE_SIZEOF	equ	20
+
+		XREF    _modelorg
+		XREF    _vpn
+		XREF    _vright
+		XREF    _vup
+		XREF    _view_clipplanes
+		XREF    _screenedge
+
+		XDEF    _R_TransformFrustum
+
+
+
+******************************************************************************
+*
+*       void R_TransformFrustum (void)
+*
+******************************************************************************
+
+		cnop    0,4
+_R_TransformFrustum
+		movem.l a2-a5,-(sp)
+		fmovem.x        fp2-fp7,-(sp)
+
+		moveq   #4-1,d0
+		;lea     _screenedge,a4
+		;lea     _view_clipplanes,a5
+		lea     _screenedge,a0
+		lea     _view_clipplanes,a1
+		lea     _modelorg,a3
+		fmove.s (a3)+,fp7
+.loop
+;		move.l  a4,a0
+;		move.l  a5,a1
+		fmove.s (a0)+,fp1
+		fneg    fp1
+		fmove.s (a0)+,fp2
+		fmove.s (a0)+,fp0
+		lea     _vright,a2
+		fmove.s (a2)+,fp3
+		fmove.s (a2)+,fp4
+		fmove.s (a2)+,fp5
+		fmul    fp1,fp3
+		fmul    fp1,fp4
+		fmul    fp1,fp5
+		lea     _vup,a2
+		fmove.s (a2)+,fp6
+		fmul    fp2,fp6
+		fadd    fp6,fp3
+		fmove.s (a2)+,fp6
+		fmul    fp2,fp6
+		fadd    fp6,fp4
+		fmove.s (a2)+,fp6
+		fmul    fp2,fp6
+		fadd    fp6,fp5
+		lea     _vpn,a2
+		fmove.s (a2)+,fp6
+		fmul    fp0,fp6
+		fadd    fp6,fp3
+		fmove.s fp3,(a1)+
+		fmove.s (a2)+,fp6
+		fmul    fp0,fp6
+		fadd    fp6,fp4
+		fmove.s fp4,(a1)+
+		fmove.s (a2)+,fp6
+		fmul    fp0,fp6
+		fadd    fp6,fp5
+		fmove.s fp5,(a1)+
+
+		fmul    fp7,fp3
+		fmul.s  (a3),fp4
+		fadd    fp4,fp3
+		fmul.s  4(a3),fp5
+		fadd    fp5,fp3
+		fmove.s fp3,(a1)+
+		lea     CLIP_SIZEOF-16(a1),a1
+		lea     MPLANE_SIZEOF-12(a0),a0
+		dbra    d0,.loop
+
+		fmovem.x        (sp)+,fp2-fp7
+		movem.l (sp)+,a2-a5
+		rts

--- a/engine/h2shared/r_local.h
+++ b/engine/h2shared/r_local.h
@@ -146,7 +146,6 @@ void R_ClearPolyList (void);
 void R_RenderBmodelFace (bedge_t *pedges, msurface_t *psurf);
 void R_RotateBmodel (void);
 void R_TransformPlane (mplane_t *p, float *normal, float *dist);
-void R_TransformFrustum (void);
 void R_SetSkyFrame (void);
 texture_t *R_TextureAnimation (texture_t *base);
 

--- a/engine/h2shared/r_shared.h
+++ b/engine/h2shared/r_shared.h
@@ -146,6 +146,7 @@ extern	int	ubasestep, errorterm, erroradjustup, erroradjustdown;
 extern	int	r_skymade;
 
 void TransformVector (vec3_t in, vec3_t out);
+void R_TransformFrustum (void);
 
 // this is in asm for m68k amiga
 void R_MakeSky (void);

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -1297,6 +1297,7 @@ SOFT_ASM = \
 	d_sprite68k.o \
 	r_aclip68k.o \
 	r_alias68k.o \
+	r_bsp68k.o \
 	r_edge68k.o \
 	r_sky68k.o \
 	r_surf68k.o

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -1027,8 +1027,8 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
 else
-# these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-tree-fre -fno-tree-sra -fno-move-loop-invariants -fno-inline-functions-called-once 
+# these break the game with bebbo's gcc-6.x:
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-tree-fre -fno-tree-sra -fno-move-loop-invariants -fno-inline-functions-called-once
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexen2/Makefile
+++ b/engine/hexen2/Makefile
@@ -1028,7 +1028,7 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 CFLAGS  += -fno-omit-frame-pointer
 else
 # these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-move-loop-invariants
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-tree-fre -fno-tree-sra -fno-move-loop-invariants -fno-inline-functions-called-once 
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexen2/r_misc.c
+++ b/engine/hexen2/r_misc.c
@@ -280,6 +280,7 @@ void R_PrintAliasStats (void)
 }
 
 
+#if	!id68k
 /*
 ===================
 R_TransformFrustum
@@ -305,6 +306,7 @@ void R_TransformFrustum (void)
 		view_clipplanes[i].dist = DotProduct (modelorg, v2);
 	}
 }
+#endif
 
 
 #if	!id386 && !id68k

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -989,7 +989,7 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 CFLAGS  += -fno-omit-frame-pointer
 else
 # these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-move-loop-invariants
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-tree-fre -fno-tree-sra -fno-move-loop-invariants -fno-inline-functions-called-once 
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -988,8 +988,8 @@ ifneq ($(BEBBO_TOOLCHAIN),yes)
 # -fomit-frame-pointer / -ffast-math causes trouble with gcc2.95
 CFLAGS  += -fno-omit-frame-pointer
 else
-# these break the game with GCC6
-CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-tree-fre -fno-tree-sra -fno-move-loop-invariants -fno-inline-functions-called-once 
+# these break the game with bebbo's gcc-6.x:
+CFLAGS  += -fbbb=- -fno-tree-forwprop -fno-tree-ter -fno-tree-fre -fno-tree-sra -fno-move-loop-invariants -fno-inline-functions-called-once
 endif
 endif
 ifeq ($(USE_CLIB2),yes)

--- a/engine/hexenworld/client/r_misc.c
+++ b/engine/hexenworld/client/r_misc.c
@@ -433,6 +433,7 @@ void R_PrintAliasStats (void)
 }
 
 
+#if	!id68k
 /*
 ===================
 R_TransformFrustum
@@ -458,6 +459,7 @@ void R_TransformFrustum (void)
 		view_clipplanes[i].dist = DotProduct (modelorg, v2);
 	}
 }
+#endif
 
 
 #if	!id386 && !id68k


### PR DESCRIPTION
There was an issue with the asm version of R_AliasTransformFinalVert, it still had the code to handle the non-existent pstverts argument. This worked by accident in UAE, but caused exceptions on real hardware. I tracked down some more bad optimizer flags as well that caused semi-random crashes in the renderer.
The last change is the asm version of R_TransformFrustum which should be slightly better than what the compiler makes.