### PR TITLE
Misc performance improvements

### DIFF
--- a/engine/h2shared/d_polyse68k.s
+++ b/engine/h2shared/d_polyse68k.s
@@ -422,13 +422,9 @@ _D_PolysetDrawSpans8T
 		move.b  0(a3,d2.l),d2           ;d2 = ((byte *)acolormap[d2]
 		lsl.w   #8,d2
 		move.b  (a0),d2                 ;d2 = (btemp<<8) + (*lpdest)
-		;move.l  a1,-(sp)
-		;move.l  _mainTransTable,a1
-		;move.b  0(a1,d2.l),(a0)         ;*lpdest = mainTransTable[d2];
-		;move.l  (sp)+,a1
 		move.b	([_mainTransTable],d2.l),(a0) ;*lpdest = mainTransTable[d2]
 		;move    d0,-2(a1)               ;*lpz = lzi >> 16
-		move    d0,(a1)                 ;*lpz = lzi >> 16
+		;move    d0,(a1)                 ;*lpz = lzi >> 16
 .cont
 		swap    d0
 .cont3
@@ -623,10 +619,6 @@ _D_PolysetDrawSpans8T2
 		move.b  0(a3,d2.l),d2           ;d2 = ((byte *)acolormap[d2]
 		lsl.w   #8,d2
 		move.b  (a0),d2                 ;d2 = (btemp<<8) + (*lpdest)
-		;move.l  a1,-(sp)
-		;move.l  _mainTransTable,a1
-		;move.b  0(a1,d2.l),(a0)         ;*lpdest = mainTransTable[d2];
-		;move.l  (sp)+,a1
 		move.b	([_mainTransTable],d2.l),(a0) ;*lpdest = mainTransTable[d2]
 .writez
 		move    d0,(a1)                 ;*lpz = lzi >> 16
@@ -983,7 +975,7 @@ _D_PolysetDrawSpans8T5
 		lsl.w   #8,d2
 		move.b  (a0),d2                 ;d2 = (btemp<<8) + (*lpdest)
 		move.b  0(a3,d2.l),(a0)         ;*lpdest = transTable[d2]
-		move    d0,(a1)                 ;*lpz = lzi >> 16
+		;move    d0,(a1)                 ;*lpz = lzi >> 16
 .cont
 		swap    d0
 .cont3
@@ -1436,7 +1428,7 @@ DoRecursionT
 		move.l  0(a5,d5.l*4),a3
 		cmp     0(a3,d4.l*2),d0         ;if (z >= *zbuf)
 		blt.b   .nodraw
-		move    d0,0(a3,d4.l*2)         ;*zbuf = z
+		;move    d0,0(a3,d4.l*2)         ;*zbuf = z
 		swap    d6
 		swap    d7
 		lea     _skintable,a3
@@ -2160,7 +2152,7 @@ DoRecursionT5
 		move.l  0(a5,d5.l*4),a3
 		cmp     0(a3,d4.l*2),d0         ;if (z >= *zbuf)
 		blt.b   .nodraw
-		move    d0,0(a3,d4.l*2)         ;*zbuf = z
+		;move    d0,0(a3,d4.l*2)         ;*zbuf = z
 		swap    d6
 		swap    d7
 		lea     _skintable,a3
@@ -3619,7 +3611,7 @@ do_PolysetDrawFinalVertsT
 		move.w	20(a6),d2				;d2 = pv->v[5]>>16
 		cmp.w	(a0),d2					;if (d2 >= *zbuf)
 		blt.b	.fvskip
-		move.w	d2,(a0)					;*zbuf = d2
+		;move.w	d2,(a0)					;*zbuf = d2
 
 		move.w	12(a6),d0				;d0 = pv->v[3]>>16
 		move.l	(a2,d0.w*4),a0			;a0 = skintable[d0]
@@ -3870,7 +3862,7 @@ do_PolysetDrawFinalVertsT5
 		move.w	20(a6),d2				;d2 = pv->v[5]>>16
 		cmp.w	(a0),d2					;if (d2 >= *zbuf)
 		blt.b	.fvskip
-		move.w	d2,(a0)					;*zbuf = d2
+		;move.w	d2,(a0)					;*zbuf = d2
 
 		move.w	12(a6),d0				;d0 = pv->v[3]>>16
 		move.l	(a2,d0.w*4),a0			;a0 = skintable[d0]

--- a/engine/h2shared/d_scan68k.s
+++ b/engine/h2shared/d_scan68k.s
@@ -1082,7 +1082,7 @@ _D_DrawTurbulent8T
 		lsl.w   #8,d4
 		move.b  (a0),d4                 ;d4 = (temp<<8) + *r_turb_pdest
 		move.b  0(a2,d4.l),(a0)
-		move.w  d5,(a5)                 ;*pz = izi >> 16
+		;move.w  d5,(a5)                 ;*pz = izi >> 16
 ; translucent
 .skipdraw
 		add.l   #1,a0                   ;r_turb_pdest++

--- a/engine/hexen2/r_misc.c
+++ b/engine/hexen2/r_misc.c
@@ -390,10 +390,10 @@ void R_SetupFrame (void)
 // don't allow cheats in multiplayer
 	if (cl.maxclients > 1)
 	{
-		Cvar_Set ("r_draworder", "0");
-		Cvar_Set ("r_fullbright", "0");
-		Cvar_Set ("r_ambient", "0");
-		Cvar_Set ("r_drawflat", "0");
+		r_draworder.integer = 0;
+		r_fullbright.integer = 0;
+		r_ambient.integer = 0;
+		r_drawflat.integer = 0;
 	}
 
 	if (r_numsurfs.integer)


### PR DESCRIPTION
These are not directly related, but I wanted to get them out of the way.

- R_SetupFrame in hexen2/r_misc.c no longer uses Cvar_Set, but clears the cvar's integer value like HexenWorld.
- Amiga VID_SetPalette speedup, the palette update is now forced after mode changes.
- Disabled Z-writes in various T and T5 functions. This also fixed some original transparency bugs, e.g. the viewmodel is no longer cut in half by the water, and transparent sprites no longer mask out transparent surfaces behind them. 