### PR TITLE
move commands and cvars used by progs to the front for faster access

### DIFF
--- a/engine/h2shared/cmd.c
+++ b/engine/h2shared/cmd.c
@@ -659,6 +659,31 @@ qboolean Cmd_CheckCommand (const char *partial)
 
 /*
 ============
+Cmd_MoveToFront
+============
+*/
+void Cmd_MoveToFront (const char *cmd_name)
+{
+	cmd_function_t	*cmd;
+	cmd_function_t	*cmd_next;
+
+	for (cmd = cmd_functions ; cmd ; cmd = cmd->next)
+	{
+		cmd_next = cmd->next;
+		if ( cmd_next && !strcmp(cmd_name, cmd_next->name) )
+		{
+			// remove from the list
+			cmd->next = cmd_next->next;
+			// move to the front
+			cmd_next->next = cmd_functions;
+			cmd_functions = cmd_next;
+			break;
+		}
+	}
+}
+
+/*
+============
 Cmd_ExecuteString
 
 A complete command line has been parsed, so try to execute it

--- a/engine/h2shared/cmd.c
+++ b/engine/h2shared/cmd.c
@@ -662,21 +662,20 @@ qboolean Cmd_CheckCommand (const char *partial)
 Cmd_MoveToFront
 ============
 */
-void Cmd_MoveToFront (const char *cmd_name)
+void Cmd_MoveToFront (const char *name)
 {
-	cmd_function_t	*cmd;
-	cmd_function_t	*cmd_next;
+	cmd_function_t	*cmd, *next;
 
-	for (cmd = cmd_functions ; cmd ; cmd = cmd->next)
+	for (cmd = cmd_functions; cmd; cmd = cmd->next)
 	{
-		cmd_next = cmd->next;
-		if ( cmd_next && !strcmp(cmd_name, cmd_next->name) )
+		next = cmd->next;
+		if (next && !strcmp(name, next->name))
 		{
 			// remove from the list
-			cmd->next = cmd_next->next;
+			cmd->next = next->next;
 			// move to the front
-			cmd_next->next = cmd_functions;
-			cmd_functions = cmd_next;
+			next->next = cmd_functions;
+			cmd_functions = next;
 			break;
 		}
 	}

--- a/engine/h2shared/cmd.h
+++ b/engine/h2shared/cmd.h
@@ -93,6 +93,9 @@ qboolean Cmd_CheckCommand (const char *partial);
 // attempts to match a given text to known commands, cvars or aliases
 // returns true if there is an exact match, false otherwise
 
+void Cmd_MoveToFront (const char *cmd_name);
+// move commands to the head of the list for faster access
+
 int		Cmd_Argc (void);
 const char	*Cmd_Argv (int arg);
 const char	*Cmd_Args (void);

--- a/engine/h2shared/cvar.c
+++ b/engine/h2shared/cvar.c
@@ -361,21 +361,20 @@ qboolean	Cvar_Command (void)
 Cvar_MoveToFront
 ============
 */
-void Cvar_MoveToFront (const char *var_name)
+void Cvar_MoveToFront (const char *name)
 {
-	cvar_t	*var;
-	cvar_t	*var_next;
+	cvar_t	*var, *next;
 
-	for (var = cvar_vars ; var ; var = var->next)
+	for (var = cvar_vars; var; var = var->next)
 	{
-		var_next = var->next;
-		if ( var_next && !strcmp(var_name, var_next->name) )
+		next = var->next;
+		if (next && !strcmp(name, next->name))
 		{
 			// remove from the list
-			var->next = var_next->next;
+			var->next = next->next;
 			// move to the front
-			var_next->next = cvar_vars;
-			cvar_vars = var_next;
+			next->next = cvar_vars;
+			cvar_vars = next;
 			break;
 		}
 	}

--- a/engine/h2shared/cvar.c
+++ b/engine/h2shared/cvar.c
@@ -356,6 +356,31 @@ qboolean	Cvar_Command (void)
 	return true;
 }
 
+/*
+============
+Cvar_MoveToFront
+============
+*/
+void Cvar_MoveToFront (const char *var_name)
+{
+	cvar_t	*var;
+	cvar_t	*var_next;
+
+	for (var = cvar_vars ; var ; var = var->next)
+	{
+		var_next = var->next;
+		if ( var_next && !strcmp(var_name, var_next->name) )
+		{
+			// remove from the list
+			var->next = var_next->next;
+			// move to the front
+			var_next->next = cvar_vars;
+			cvar_vars = var_next;
+			break;
+		}
+	}
+}
+
 
 /*
 ============

--- a/engine/h2shared/cvar.h
+++ b/engine/h2shared/cvar.h
@@ -123,6 +123,9 @@ qboolean Cvar_Command (void);
 // command.  Returns true if the command was a variable reference that
 // was handled. (print or change)
 
+void Cvar_MoveToFront (const char *var_name);
+// move variables to the head of the list for faster access
+
 void	Cvar_WriteVariables (FILE *f);
 // Writes lines containing "set variable value" for all variables
 // with the CVAR_ARCHIVE flag set

--- a/engine/hexen2/host.c
+++ b/engine/hexen2/host.c
@@ -1052,6 +1052,12 @@ void Host_Init (void)
 
 	CFG_CloseConfig();
 
+// move commands and cvars used by progs to the front for faster access
+	Cmd_MoveToFront ("bf");
+	Cvar_MoveToFront ("teamplay");
+	Cvar_MoveToFront ("skill");
+	Cvar_MoveToFront ("registered");
+
 #ifdef GLQUAKE
 /* analogous to host_hunklevel, this will mark OpenGL texture
  * beyond which everything will need to be purged on new map */

--- a/engine/hexenworld/client/cl_main.c
+++ b/engine/hexenworld/client/cl_main.c
@@ -1422,6 +1422,9 @@ void Host_Init (void)
 
 	CFG_CloseConfig();
 
+// move commands and cvars used by progs to the front for faster access
+	Cmd_MoveToFront ("bf");
+
 #ifdef GLQUAKE
 /* analogous to host_hunklevel, this will mark OpenGL texture
  * beyond which everything will need to be purged on new map */


### PR DESCRIPTION
Host_Init in the clients now moves the most frequently used prog commands and cvars to the front of the list, so they can be retrieved with the fewest lookups. Fortunately there aren't many of these, so this works well for the stock progs.