### PR TITLE
added solid color surface drawing functions

### DIFF
--- a/engine/h2shared/model.c
+++ b/engine/h2shared/model.c
@@ -1076,23 +1076,21 @@ static void Mod_SetDrawingFlags(msurface_t *out)
 		return;
 	}
 
+	if (out->texinfo->texture->anim_total)
+		return;
+	// BSzili: for D_DrawSolidSurface optimization:
 	if (!strncmp(out->texinfo->texture->name, "rtex", 4))	// solid color
 	{
-		texture_t	*texture;
-		byte	*pixels;
-		int		size;
-
-		texture = out->texinfo->texture;
-		pixels = (byte *)texture + texture->offsets[0];
-		size = texture->width * texture->height;
+		const texture_t *texture = out->texinfo->texture;
+		const byte *pixels = (byte *)texture + texture->offsets[0];
+		const int size = texture->width * texture->height;
 
 		for (i = 1; i < size; i++)
 		{
 			if (pixels[i] != pixels[0])
-				break;
+				return;
 		}
-		if (i == size && !texture->anim_total)
-			out->flags |= SURF_DRAWSOLID;
+		out->flags |= SURF_DRAWSOLID;
 	}
 }
 

--- a/engine/h2shared/model.c
+++ b/engine/h2shared/model.c
@@ -1075,6 +1075,25 @@ static void Mod_SetDrawingFlags(msurface_t *out)
 
 		return;
 	}
+
+	if (!strncmp(out->texinfo->texture->name, "rtex", 4))	// solid color
+	{
+		texture_t	*texture;
+		byte	*pixels;
+		int		size;
+
+		texture = out->texinfo->texture;
+		pixels = (byte *)texture + texture->offsets[0];
+		size = texture->width * texture->height;
+
+		for (i = 1; i < size; i++)
+		{
+			if (pixels[i] != pixels[0])
+				break;
+		}
+		if (i == size && !texture->anim_total)
+			out->flags |= SURF_DRAWSOLID;
+	}
 }
 
 

--- a/engine/h2shared/model.h
+++ b/engine/h2shared/model.h
@@ -87,6 +87,7 @@ typedef struct texture_s
 #define SURF_DRAWBACKGROUND	0x40
 #define SURF_TRANSLUCENT	0x80	/* r_edge.asm checks this */
 #define SURF_DRAWBLACK		0x100
+#define SURF_DRAWSOLID		0x200
 
 // !!! if this is changed, it must be changed in asm_draw.h too !!!
 typedef struct


### PR DESCRIPTION
Many levels use a completely white texture for various transparent light effects (teleporters, light shafts, etc). The name can vary from map to map, so I added some code to Mod_SetDrawingFlags to detect it and set a surface flag, so they can be drawn with a specialized functions in D_DrawSurfaces. This looks the same as the original, but without the cost of drawing textured spans.