### PR TITLE
Fixed the meso2 and romeric5 maps on Amiga

### DIFF
--- a/engine/hexen2/sv_phys.c
+++ b/engine/hexen2/sv_phys.c
@@ -140,7 +140,12 @@ static qboolean SV_RunThink (edict_t *ent)
 	float	thinktime;
 
 	thinktime = ent->v.nextthink;
+#ifdef PLATFORM_AMIGAOS3
+	// SV_SpawnServer race condition workaround for meso2 and romeric5
+	if (thinktime <= 0 || (thinktime + 0.0000001) > sv.time + host_frametime)
+#else
 	if (thinktime <= 0 || thinktime > sv.time + host_frametime)
+#endif
 		return true;
 
 	if (thinktime < sv.time)
@@ -1302,7 +1307,12 @@ static void SV_Physics_Pusher (edict_t *ent)
 			SV_PushMove (ent, movetime, true);	// advances ent->v.ltime if not blocked
 	}
 
+#ifdef PLATFORM_AMIGAOS3
+	// SV_SpawnServer race condition workaround for meso2 and romeric5
+	if (thinktime > oldltime && (thinktime - 0.00000001) <= ent->v.ltime)
+#else
 	if (thinktime > oldltime && thinktime <= ent->v.ltime)
+#endif
 	{
 		ent->v.nextthink = 0;
 		*sv_globals.time = sv.time;

--- a/engine/hexenworld/client/Makefile
+++ b/engine/hexenworld/client/Makefile
@@ -1263,6 +1263,7 @@ SOFT_ASM = \
 	d_sprite68k.o \
 	r_aclip68k.o \
 	r_alias68k.o \
+	r_bsp68k.o \
 	r_edge68k.o \
 	r_sky68k.o \
 	r_surf68k.o

--- a/engine/hexenworld/server/sv_phys.c
+++ b/engine/hexenworld/server/sv_phys.c
@@ -1327,7 +1327,12 @@ static void SV_Physics_Pusher (edict_t *ent)
 			SV_PushMove (ent, movetime, true);	// advances ent->v.ltime if not blocked
 	}
 
+#ifdef PLATFORM_AMIGAOS3
+	// SV_SpawnServer race condition workaround for meso2 and romeric5
+	if (thinktime > oldltime && (thinktime - 0.00000001) <= ent->v.ltime)
+#else
 	if (thinktime > oldltime && thinktime <= ent->v.ltime)
+#endif
 	{
 		VectorCopy (ent->v.origin, oldorg);
 


### PR DESCRIPTION
On Amiga there was a race condition in the order the entities get to think first when SV_SpawnServer is run. It was caused by the double to float conversion of host_frametime in SV_Physics_Pusher and later sv.time + host_frametime in SV_RunThink. Because of this some doors could be used or touched before their InitDoor function is executed causing a program error. I tried multiple ways to fix it, but it quickly became a game of whack-a-mole, so I ended up adding small constants to these checks to give them a bit of tolerance. 