### PR TITLE
added fast approximate vector and square root functions

### DIFF
--- a/engine/h2shared/d_sky.c
+++ b/engine/h2shared/d_sky.c
@@ -59,7 +59,7 @@ static void D_Sky_uv_To_st (int u, int v, fixed16_t *s, fixed16_t *t)
 	end[2] = vpn[2] + wu*vright[2] + wv*vup[2];
 	// ToChriS - end
 	end[2] *= 3;
-	VectorNormalize (end);
+	VectorNormalizeFast (end);
 
 	temp = skytime*skyspeed;	// TODO: add D_SetupFrame & set this there
 	*s = (int)((temp + 6*(SKYSIZE/2-1)*end[0]) * 0x10000);

--- a/engine/h2shared/gl_rlight.c
+++ b/engine/h2shared/gl_rlight.c
@@ -120,7 +120,7 @@ static void R_RenderDlight (dlight_t *light)
 	rad = light->radius * 0.35;
 
 	VectorSubtract (light->origin, r_origin, v);
-	if (VectorLength (v) < rad)
+	if (VectorLengthFast (v) < rad)
 	{	// view is inside the dlight
 		AddLightBlend (1, 0.5, 0, light->radius * 0.0003);
 		return;

--- a/engine/h2shared/r_sprite.c
+++ b/engine/h2shared/r_sprite.c
@@ -308,7 +308,7 @@ void R_DrawSprite (void)
 		tvec[0] = -modelorg[0];
 		tvec[1] = -modelorg[1];
 		tvec[2] = -modelorg[2];
-		VectorNormalize (tvec);
+		VectorNormalizeFast (tvec);
 		dot = tvec[2];	// same as DotProduct (tvec, r_spritedesc.vup) because
 						//  r_spritedesc.vup is 0, 0, 1
 		if ((dot > 0.999848) || (dot < -0.999848))	// cos(1 degree) = 0.999848
@@ -321,7 +321,7 @@ void R_DrawSprite (void)
 		r_spritedesc.vright[1] = -tvec[0];
 								//              r_spritedesc.vright)
 		r_spritedesc.vright[2] = 0;
-		VectorNormalize (r_spritedesc.vright);
+		VectorNormalizeFast (r_spritedesc.vright);
 		r_spritedesc.vpn[0] = -r_spritedesc.vright[1];
 		r_spritedesc.vpn[1] = r_spritedesc.vright[0];
 		r_spritedesc.vpn[2] = 0;
@@ -359,7 +359,7 @@ void R_DrawSprite (void)
 							// CrossProduct (r_spritedesc.vup, vpn,
 		r_spritedesc.vright[1] = -vpn[0];	//  r_spritedesc.vright)
 		r_spritedesc.vright[2] = 0;
-		VectorNormalize (r_spritedesc.vright);
+		VectorNormalizeFast (r_spritedesc.vright);
 		r_spritedesc.vpn[0] = -r_spritedesc.vright[1];
 		r_spritedesc.vpn[1] = r_spritedesc.vright[0];
 		r_spritedesc.vpn[2] = 0;

--- a/engine/h2shared/snd_dma.c
+++ b/engine/h2shared/snd_dma.c
@@ -498,7 +498,7 @@ void SND_Spatialize (channel_t *ch)
 
 // calculate stereo seperation and distance attenuation
 	VectorSubtract(ch->origin, listener_origin, source_vec);
-	dist = VectorNormalize(source_vec) * ch->dist_mult;
+	dist = VectorNormalizeFast(source_vec) * ch->dist_mult;
 	dot = DotProduct(listener_right, source_vec);
 
 	if (shm->channels == 1)

--- a/engine/hexen2/chase.c
+++ b/engine/hexen2/chase.c
@@ -87,7 +87,7 @@ void Chase_Update (void)
 
 // check for walls between player and camera (from quakeforge)
 	TraceLine(r_refdef.vieworg, chase_dest, stop);
-	if (VectorLength(stop) != 0)
+	if (VectorLengthFast(stop) != 0)
 	{
 		chase_dest[0] = stop[0] + forward[0] * 8;
 		chase_dest[1] = stop[1] + forward[1] * 8;

--- a/engine/hexen2/cl_effect.c
+++ b/engine/hexen2/cl_effect.c
@@ -1045,7 +1045,7 @@ void CL_UpdateEffects (void)
 
 			VectorSubtract(snow_org, r_origin, snow_org);
 
-			distance = VectorNormalize(snow_org);
+			distance = VectorNormalizeFast(snow_org);
 
 			cl.Effects[idx].ef.Rain.next_time += frametime;
 			/* jfm:  fixme, check distance to player first */

--- a/engine/hexen2/cl_tent.c
+++ b/engine/hexen2/cl_tent.c
@@ -453,14 +453,14 @@ void CL_UpdateTEnts(void)
 			yaw = (int)(atan2(dist[1], dist[0])*180/M_PI);
 			if (yaw < 0)
 				yaw += 360;
-			forward = sqrt(dist[0]*dist[0]+dist[1]*dist[1]);
+			forward = Q_sqrt(dist[0]*dist[0]+dist[1]*dist[1]);
 			pitch = (int)(atan2(dist[2], forward)*180/M_PI);
 			if (pitch < 0)
 				pitch += 360;
 		}
 
 		VectorCopy(stream->source, org);
-		d = VectorNormalize(dist);
+		d = VectorNormalizeFast(dist);
 
 		if (stream->type == TE_STREAM_ICECHUNKS)
 		{

--- a/engine/hexen2/gl_rmain.c
+++ b/engine/hexen2/gl_rmain.c
@@ -773,7 +773,7 @@ static void R_DrawAliasModel (entity_t *e)
 			if (cl_dlights[lnum].die >= cl.time)
 			{
 				VectorSubtract (e->origin, cl_dlights[lnum].origin, dist);
-				add = cl_dlights[lnum].radius - VectorLength(dist);
+				add = cl_dlights[lnum].radius - VectorLengthFast(dist);
 				if (add > 0)
 				{
 					ambientlight += add;
@@ -1415,7 +1415,7 @@ static void R_DrawViewModel (void)
 			continue;
 
 		VectorSubtract (e->origin, dl->origin, dist);
-		add = dl->radius - VectorLength(dist);
+		add = dl->radius - VectorLengthFast(dist);
 		if (add > 0)
 		{
 			if (gl_lightmap_format == GL_RGBA)

--- a/engine/hexen2/r_alias.c
+++ b/engine/hexen2/r_alias.c
@@ -405,7 +405,7 @@ static void R_AliasSetUpTransform (int trivial_accept)
 	{
 		VectorSubtract(currententity->origin,r_origin,angles);
 		VectorSubtract(r_origin,currententity->origin,angles);
-		VectorNormalize(angles);
+		VectorNormalizeFast(angles);
 
 		if (angles[1] == 0 && angles[0] == 0)
 		{
@@ -421,7 +421,7 @@ static void R_AliasSetUpTransform (int trivial_accept)
 			if (yaw < 0)
 				yaw += 360;
 
-			forward = sqrt (angles[0]*angles[0] + angles[1]*angles[1]);
+			forward = Q_sqrt (angles[0]*angles[0] + angles[1]*angles[1]);
 			pitch = (int) (atan2(angles[2], forward) * 180 / M_PI);
 			if (pitch < 0)
 				pitch += 360;

--- a/engine/hexen2/r_main.c
+++ b/engine/hexen2/r_main.c
@@ -653,14 +653,14 @@ static void R_PrepareAlias (void)
 
 					if (cl_dlights[lnum].radius> 0)
 					{
-						add = cl_dlights[lnum].radius - VectorLength(dist);
+						add = cl_dlights[lnum].radius - VectorLengthFast(dist);
 
 						if (add > 0)
 							lighting.ambientlight += add;
 					}
 					else
 					{
-						add = VectorLength(dist) + cl_dlights[lnum].radius;
+						add = VectorLengthFast(dist) + cl_dlights[lnum].radius;
 
 						if (add < 0)
 							lighting.ambientlight += add;
@@ -818,14 +818,14 @@ static void R_DrawViewModel (void)
 
 			if (dl->radius > 0)
 			{
-				add = dl->radius - VectorLength(dist);
+				add = dl->radius - VectorLengthFast(dist);
 
 				if (add > 0)
 					r_viewlighting.ambientlight += add;
 			}
 			else
 			{
-				add = VectorLength(dist) + dl->radius;
+				add = VectorLengthFast(dist) + dl->radius;
 
 				if (add < 0)
 					r_viewlighting.ambientlight += add;

--- a/engine/hexen2/r_part.c
+++ b/engine/hexen2/r_part.c
@@ -141,7 +141,7 @@ void R_DarkFieldParticles (entity_t *ent)
 				p->org[1] = org[1] + j + (rand() & 3);
 				p->org[2] = org[2] + k + (rand() & 3);
 
-				VectorNormalize (dir);
+				VectorNormalizeFast (dir);
 				vel = 50 + (rand() & 63);
 				VectorScale (dir, vel, p->vel);
 			}
@@ -711,7 +711,7 @@ void R_LavaSplash (vec3_t org)
 				p->org[1] = org[1] + dir[1];
 				p->org[2] = org[2] + (rand() & 63);
 
-				VectorNormalize (dir);
+				VectorNormalizeFast (dir);
 				vel = 50 + (rand() & 63);
 				VectorScale (dir, vel, p->vel);
 			}
@@ -754,7 +754,7 @@ void R_TeleportSplash (vec3_t org)
 				p->org[1] = org[1] + j + (rand() & 3);
 				p->org[2] = org[2] + k + (rand() & 3);
 
-				VectorNormalize (dir);
+				VectorNormalizeFast (dir);
 				vel = 50 + (rand() & 63);
 				VectorScale (dir, vel, p->vel);
 			}
@@ -820,7 +820,7 @@ void R_SunStaffTrail(vec3_t source, vec3_t dest)
 	float		length, size;
 
 	VectorSubtract(dest, source, vec);
-	length = VectorNormalize(vec);
+	length = VectorNormalizeFast(vec);
 	dist[0] = vec[0];
 	dist[1] = vec[1];
 	dist[2] = vec[2];
@@ -939,7 +939,7 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 	static int tracercount;
 
 	VectorSubtract (end, start, vec);
-	len = VectorNormalize (vec);
+	len = VectorNormalizeFast (vec);
 	dist[0] = vec[0];
 	dist[1] = vec[1];
 	dist[2] = vec[2];
@@ -1648,7 +1648,7 @@ void R_UpdateParticles (void)
 					snow_speed = p->vel[0] * p->vel[0] +
 							p->vel[1] * p->vel[1] +
 							p->vel[2] * p->vel[2];
-					snow_speed = sqrt(snow_speed);
+					snow_speed = Q_sqrt(snow_speed);
 
 					VectorCopy(p->vel, save_vel);
 
@@ -1657,7 +1657,7 @@ void R_UpdateParticles (void)
 					if ((rand() & 7) || p->vel[2] > 10)
 						save_vel[2] += ( (rand() * (2.0 / RAND_MAX)) - 1 ) * 30;
 
-					VectorNormalize(save_vel);
+					VectorNormalizeFast(save_vel);
 					VectorScale(save_vel, snow_speed, p->vel);	// retain speed but use new dir
 				    }
 				}

--- a/engine/hexen2/view.c
+++ b/engine/hexen2/view.c
@@ -115,7 +115,7 @@ static float V_CalcBob (void)
 	// bob is proportional to velocity in the xy plane
 	// (don't count Z, or jumping messes it up)
 
-	bob = sqrt(cl.velocity[0]*cl.velocity[0] + cl.velocity[1]*cl.velocity[1]) * cl_bob.value;
+	bob = Q_sqrt(cl.velocity[0]*cl.velocity[0] + cl.velocity[1]*cl.velocity[1]) * cl_bob.value;
 	bob = bob*0.3 + bob*0.7*q_sinrad(cycle);
 	if (bob > 4)
 		bob = 4;
@@ -373,7 +373,7 @@ void V_ParseDamage (void)
 	ent = &cl_entities[cl.viewentity];
 
 	VectorSubtract (from, ent->origin, from);
-	VectorNormalize (from);
+	VectorNormalizeFast (from);
 
 	AngleVectors (ent->angles, forward, right, up);
 

--- a/engine/hexenworld/client/cl_effect.c
+++ b/engine/hexenworld/client/cl_effect.c
@@ -90,7 +90,7 @@ static void vectoangles (vec3_t vec, vec3_t ang)
 		if (yaw < 0)
 			yaw += 360;
 
-		forward = sqrt (vec[0]*vec[0] + vec[1]*vec[1]);
+		forward = Q_sqrt (vec[0]*vec[0] + vec[1]*vec[1]);
 		pitch = (int) (atan2(vec[2], forward) * 180 / M_PI);
 		if (pitch < 0)
 			pitch += 360;
@@ -889,7 +889,7 @@ void CL_ParseEffect (void)
 
 		AngleVectors (cl.Effects[idx].ef.Xbow.angle, forward, right, up);
 
-		VectorNormalize(forward);
+		VectorNormalizeFast(forward);
 		VectorCopy(forward, cl.Effects[idx].ef.Xbow.velocity);
 	//	VectorScale(forward, 1000, cl.Effects[idx].ef.Xbow.velocity);
 
@@ -967,7 +967,7 @@ void CL_ParseEffect (void)
 
 		AngleVectors (cl.Effects[idx].ef.Xbow.angle, forward, right, up);
 
-		VectorNormalize(forward);
+		VectorNormalizeFast(forward);
 		VectorCopy(forward, cl.Effects[idx].ef.Xbow.velocity);
 
 	//	S_StartSound (TempSoundChannel(), 1, cl_fxsfx_xbowshoot, origin, 1, 1);
@@ -1306,7 +1306,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 
 					/* make sure bolt is in correct position */
 					VectorCopy(cl.Effects[idx].ef.Xbow.vel[curEnt], forward);
-					VectorNormalize(forward);
+					VectorNormalizeFast(forward);
 					VectorScale(forward, dist, forward);
 					VectorAdd(cl.Effects[idx].ef.Xbow.origin[curEnt], forward, ent->origin);
 
@@ -1323,7 +1323,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 					}
 
 					VectorCopy(cl.Effects[idx].ef.Xbow.vel[curEnt], forward);
-					VectorNormalize(forward);
+					VectorNormalizeFast(forward);
 					VectorScale(forward, 8, forward);
 
 					/* do a particle effect here, with the color depending on chType */
@@ -1374,7 +1374,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 					}
 
 					AngleVectors(ent->angles, forward, right, up);
-					speed = VectorLength(cl.Effects[idx].ef.Xbow.vel[curEnt]);
+					speed = VectorLengthFast(cl.Effects[idx].ef.Xbow.vel[curEnt]);
 					VectorScale(forward, speed, cl.Effects[idx].ef.Xbow.vel[curEnt]);
 					VectorCopy(cl.Effects[idx].ef.Xbow.origin[curEnt], ent->origin);
 				}
@@ -1397,7 +1397,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 					}
 
 					AngleVectors(pos, forward, right,up);
-					speed = VectorLength(cl.Effects[idx].ef.Xbow.vel[curEnt]);
+					speed = VectorLengthFast(cl.Effects[idx].ef.Xbow.vel[curEnt]);
 					VectorScale(forward, speed, cl.Effects[idx].ef.Xbow.vel[curEnt]);
 				}
 			}
@@ -1417,7 +1417,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 
 					/* make sure bolt is in correct position */
 					VectorCopy(cl.Effects[idx].ef.Xbow.vel[curEnt], forward);
-					VectorNormalize(forward);
+					VectorNormalizeFast(forward);
 					VectorScale(forward, dist, forward);
 					VectorAdd(cl.Effects[idx].ef.Xbow.origin[curEnt], forward, ent->origin);
 					R_ColoredParticleExplosion(ent->origin,
@@ -1446,7 +1446,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 					}
 
 					AngleVectors(ent->angles, forward, right, up);
-					speed = VectorLength(cl.Effects[idx].ef.Xbow.vel[curEnt]);
+					speed = VectorLengthFast(cl.Effects[idx].ef.Xbow.vel[curEnt]);
 					VectorScale(forward, speed, cl.Effects[idx].ef.Xbow.vel[curEnt]);
 					VectorCopy(cl.Effects[idx].ef.Xbow.origin[curEnt], ent->origin);
 				}
@@ -1469,7 +1469,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 					}
 
 					AngleVectors(pos, forward, right, up);
-					speed = VectorLength(cl.Effects[idx].ef.Xbow.vel[curEnt]);
+					speed = VectorLengthFast(cl.Effects[idx].ef.Xbow.vel[curEnt]);
 					VectorScale(forward, speed, cl.Effects[idx].ef.Xbow.vel[curEnt]);
 				}
 			}
@@ -1500,7 +1500,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 
 				/* lil bits at exit */
 				VectorCopy(cl.Effects[idx].ef.Missile.velocity, forward);
-				VectorNormalize(forward);
+				VectorNormalizeFast(forward);
 				VectorScale(forward, 36, forward);
 				VectorAdd(forward, pos, pos);
 				XbowImpactPuff(pos, material);
@@ -1522,7 +1522,7 @@ void CL_ReviseEffect(void)	/* be sure to read, in the switch statement, everythi
 				cl.Effects[idx].ef.Missile.origin[2] = MSG_ReadCoord();
 
 				AngleVectors(ent->angles, forward, right, up);
-				speed = VectorLength(cl.Effects[idx].ef.Missile.velocity);
+				speed = VectorLengthFast(cl.Effects[idx].ef.Missile.velocity);
 				VectorScale(forward, speed, cl.Effects[idx].ef.Missile.velocity);
 				VectorCopy(cl.Effects[idx].ef.Missile.origin, ent->origin);
 			}
@@ -2128,7 +2128,7 @@ void CL_UpdateEffects (void)
 								ent = &EffectEntities[cl.Effects[idx].ef.Xbow.ent[i]];
 
 								/* move bolt back a little to make explosion look better */
-								VectorNormalize(cl.Effects[idx].ef.Xbow.vel[i]);
+								VectorNormalizeFast(cl.Effects[idx].ef.Xbow.vel[i]);
 								VectorScale(cl.Effects[idx].ef.Xbow.vel[i], -8,
 										cl.Effects[idx].ef.Xbow.vel[i]);
 								VectorAdd(ent->origin, cl.Effects[idx].ef.Xbow.vel[i],
@@ -2249,7 +2249,7 @@ void CL_UpdateEffects (void)
 					VectorCopy(es->origin, org);
 					org[2] += cl.Effects[idx].ef.Chain.height;
 					VectorSubtract(org, ent->origin, org);
-					if (fabs(VectorNormalize(org)) < 500*frametime)
+					if (fabs(VectorNormalizeFast(org)) < 500*frametime)
 					{
 						S_StartSound (TempSoundChannel(), 1, cl_fxsfx_scarabgrab,
 											ent->origin, 1, 1);
@@ -2278,7 +2278,7 @@ void CL_UpdateEffects (void)
 			/* unattaching, server needs to set this state */
 				VectorCopy(ent->origin, org);
 				VectorSubtract(cl.Effects[idx].ef.Chain.origin, org, org);
-				if (fabs(VectorNormalize(org)) > 350*frametime)
+				if (fabs(VectorNormalizeFast(org)) > 350*frametime)
 								/* closer than 30 is too close? */
 				{
 					VectorScale(org, 350*frametime, org);

--- a/engine/hexenworld/client/cl_tent.c
+++ b/engine/hexenworld/client/cl_tent.c
@@ -271,7 +271,7 @@ static void vectoangles(vec3_t vec, vec3_t ang)
 		yaw = (int) (atan2(vec[1], vec[0]) * 180 / M_PI);
 		if (yaw < 0)
 			yaw += 360;
-		forward = sqrt (vec[0]*vec[0] + vec[1]*vec[1]);
+		forward = Q_sqrt (vec[0]*vec[0] + vec[1]*vec[1]);
 		pitch = (int) (atan2(vec[2], forward) * 180 / M_PI);
 		if (pitch < 0)
 			pitch += 360;
@@ -2412,7 +2412,7 @@ void CL_ParseTEnt (void)
 			VectorScale(midPos,0.5,midPos);
 
 			VectorSubtract(midPos,pos,distVec);
-			distance = (int)(VectorNormalize(distVec)*0.025);
+			distance = (int)(VectorNormalizeFast(distVec)*0.025);
 			if (distance > 0)
 			{
 				VectorScale(distVec,40,distVec);
@@ -3487,7 +3487,7 @@ static void CL_UpdateBeams (void)
 			yaw = (int) (atan2(dist[1], dist[0]) * 180 / M_PI);
 			if (yaw < 0)
 				yaw += 360;
-			forward = sqrt (dist[0]*dist[0] + dist[1]*dist[1]);
+			forward = Q_sqrt (dist[0]*dist[0] + dist[1]*dist[1]);
 			pitch = (int) (atan2(dist[2], forward) * 180 / M_PI);
 			if (pitch < 0)
 				pitch += 360;
@@ -3495,7 +3495,7 @@ static void CL_UpdateBeams (void)
 
 	// add new entities for the lightning
 		VectorCopy (b->start, org);
-		d = VectorNormalize(dist);
+		d = VectorNormalizeFast(dist);
 		while (d > 0)
 		{
 			ent = CL_NewTempEntity ();
@@ -3662,14 +3662,14 @@ static void CL_UpdateStreams(void)
 			yaw = (int)(atan2(dist[1], dist[0])*180/M_PI);
 			if (yaw < 0)
 				yaw += 360;
-			forward = sqrt(dist[0]*dist[0]+dist[1]*dist[1]);
+			forward = Q_sqrt(dist[0]*dist[0]+dist[1]*dist[1]);
 			pitch = (int)(atan2(dist[2], forward)*180/M_PI);
 			if (pitch < 0)
 				pitch += 360;
 		}
 
 		VectorCopy(stream->source, org);
-		d = VectorNormalize(dist);
+		d = VectorNormalizeFast(dist);
 
 		if (stream->type == TE_STREAM_SUNSTAFF2)
 		{
@@ -4084,7 +4084,7 @@ static void ChunkThink(explosion_t *ex)
 
 		if ((int)ex->data == THINGTYPE_FLESH)
 		{
-			if (VectorNormalize(ex->velocity) > 100.0)
+			if (VectorNormalizeFast(ex->velocity) > 100.0)
 			{	// hit, now make a splash of blood
 				vec3_t	dmin = {-40, -40, 10};
 				vec3_t	dmax = {40, 40, 40};
@@ -4095,7 +4095,7 @@ static void ChunkThink(explosion_t *ex)
 		}
 		else if ((int)ex->data == THINGTYPE_ACID)
 		{
-			if (VectorNormalize(ex->velocity) > 100.0)
+			if (VectorNormalizeFast(ex->velocity) > 100.0)
 			{	// hit, now make a splash of acid
 			//	vec3_t	dmin = {-40, -40, 10};
 			//	vec3_t	dmax = {40, 40, 40};
@@ -4798,7 +4798,7 @@ void CL_UpdatePowerFlameBurn(entity_t *ent, int edict_num)
 		VectorCopy(srcVec, ex->velocity);
 		ex->velocity[2] += 24;
 		VectorScale(ex->velocity, 1.0 / .25, ex->velocity);
-		VectorNormalize(srcVec);
+		VectorNormalizeFast(srcVec);
 		vectoangles(srcVec, ex->angles);
 
 		ex->flags |= MLS_ABSLIGHT;//|DRF_TRANSLUCENT;
@@ -4920,7 +4920,7 @@ static void telPuffMove (explosion_t *ex)
 
 	VectorSubtract(ex->angles, ex->origin, tvec);
 	VectorCopy(tvec,tvec2);
-	VectorNormalize(tvec);
+	VectorNormalizeFast(tvec);
 	VectorScale(tvec,320,tvec);
 
 	ex->velocity[0] = tvec[1];

--- a/engine/hexenworld/client/gl_rmain.c
+++ b/engine/hexenworld/client/gl_rmain.c
@@ -833,7 +833,7 @@ static void R_DrawAliasModel (entity_t *e)
 			if (cl_dlights[lnum].die >= cl.time)
 			{
 				VectorSubtract (e->origin, cl_dlights[lnum].origin, dist);
-				add = cl_dlights[lnum].radius - VectorLength(dist);
+				add = cl_dlights[lnum].radius - VectorLengthFast(dist);
 				if (add > 0)
 				{
 					ambientlight += add;
@@ -1498,7 +1498,7 @@ static void R_DrawViewModel (void)
 			continue;
 
 		VectorSubtract (e->origin, dl->origin, dist);
-		add = dl->radius - VectorLength(dist);
+		add = dl->radius - VectorLengthFast(dist);
 		if (add > 0)
 		{
 			if (gl_lightmap_format == GL_RGBA)

--- a/engine/hexenworld/client/r_alias.c
+++ b/engine/hexenworld/client/r_alias.c
@@ -398,7 +398,7 @@ static void R_AliasSetUpTransform (int trivial_accept)
 	{
 		VectorSubtract(currententity->origin,r_origin,angles);
 		VectorSubtract(r_origin,currententity->origin,angles);
-		VectorNormalize(angles);
+		VectorNormalizeFast(angles);
 
 		if (angles[1] == 0 && angles[0] == 0)
 		{
@@ -414,7 +414,7 @@ static void R_AliasSetUpTransform (int trivial_accept)
 			if (yaw < 0)
 				yaw += 360;
 
-			forward = sqrt (angles[0]*angles[0] + angles[1]*angles[1]);
+			forward = Q_sqrt (angles[0]*angles[0] + angles[1]*angles[1]);
 			pitch = (int) (atan2(angles[2], forward) * 180 / M_PI);
 			if (pitch < 0)
 				pitch += 360;

--- a/engine/hexenworld/client/r_main.c
+++ b/engine/hexenworld/client/r_main.c
@@ -692,14 +692,14 @@ static void R_PrepareAlias (void)
 
 					if (cl_dlights[lnum].radius> 0)
 					{
-						add = cl_dlights[lnum].radius - VectorLength(dist);
+						add = cl_dlights[lnum].radius - VectorLengthFast(dist);
 
 						if (add > 0)
 							lighting.ambientlight += add;
 					}
 					else
 					{
-						add = VectorLength(dist) + cl_dlights[lnum].radius;
+						add = VectorLengthFast(dist) + cl_dlights[lnum].radius;
 
 						if (add < 0)
 							lighting.ambientlight += add;
@@ -848,14 +848,14 @@ static void R_DrawViewModel (void)
 
 			if (dl->radius > 0)
 			{
-				add = dl->radius - VectorLength(dist);
+				add = dl->radius - VectorLengthFast(dist);
 
 				if (add > 0)
 					r_viewlighting.ambientlight += add;
 			}
 			else
 			{
-				add = VectorLength(dist) + dl->radius;
+				add = VectorLengthFast(dist) + dl->radius;
 
 				if (add < 0)
 					r_viewlighting.ambientlight += add;

--- a/engine/hexenworld/client/r_part.c
+++ b/engine/hexenworld/client/r_part.c
@@ -128,7 +128,7 @@ void R_DarkFieldParticles (entity_t *ent)
 				p->org[1] = org[1] + j + (rand() & 3);
 				p->org[2] = org[2] + k + (rand() & 3);
 
-				VectorNormalize (dir);
+				VectorNormalizeFast (dir);
 				vel = 50 + (rand() & 63);
 				VectorScale (dir, vel, p->vel);
 			}
@@ -819,7 +819,7 @@ void R_LavaSplash (vec3_t org)
 				p->org[1] = org[1] + dir[1];
 				p->org[2] = org[2] + (rand() & 63);
 
-				VectorNormalize (dir);
+				VectorNormalizeFast (dir);
 				vel = 50 + (rand() & 63);
 				VectorScale (dir, vel, p->vel);
 			}
@@ -865,7 +865,7 @@ void R_TargetBallEffect (vec3_t org)
 		p->org[1] = org[1] + (rand() & 3) - 2;
 		p->org[2] = org[2] + (rand() & 3);
 
-		VectorNormalize (dir);
+		VectorNormalizeFast (dir);
 		vel = 50 + (rand() & 63);
 		VectorScale (dir, vel, p->vel);
 	}
@@ -907,7 +907,7 @@ void R_BrightFieldSource (vec3_t org)
 	//	p->org[2] = org[2] + (rand() & 3);
 		p->org[2] = org[2] + height;
 
-		VectorNormalize (dir);
+		VectorNormalizeFast (dir);
 		vel = 70 + (rand() & 31);
 		VectorScale (dir, vel, p->vel);
 	}
@@ -931,7 +931,7 @@ void R_BrightFieldSource (vec3_t org)
 	//	p->org[2] = org[2] + (rand() & 3);
 		p->org[2] = org[2] - height;
 
-		VectorNormalize (dir);
+		VectorNormalizeFast (dir);
 		vel = 70 + (rand() & 31);
 		VectorScale (dir, vel, p->vel);
 	}
@@ -972,7 +972,7 @@ void R_TeleportSplash (vec3_t org)
 				p->org[1] = org[1] + j + (rand() & 3);
 				p->org[2] = org[2] + k + (rand() & 3);
 
-				VectorNormalize (dir);
+				VectorNormalizeFast (dir);
 				vel = 50 + (rand() & 63);
 				VectorScale (dir, vel, p->vel);
 			}
@@ -1045,7 +1045,7 @@ void R_SunStaffTrail(vec3_t source, vec3_t dest)
 	float		length, size;
 
 	VectorSubtract(dest, source, vec);
-	length = VectorNormalize(vec);
+	length = VectorNormalizeFast(vec);
 	dist[0] = vec[0];
 	dist[1] = vec[1];
 	dist[2] = vec[2];
@@ -1131,7 +1131,7 @@ void R_RocketTrail (vec3_t start, vec3_t end, int type)
 	static int tracercount;
 
 	VectorSubtract (end, start, vec);
-	len = VectorNormalize (vec);
+	len = VectorNormalizeFast (vec);
 	dist[0] = vec[0];
 	dist[1] = vec[1];
 	dist[2] = vec[2];

--- a/engine/hexenworld/client/view.c
+++ b/engine/hexenworld/client/view.c
@@ -119,7 +119,7 @@ static float V_CalcBob (void)
 	// bob is proportional to simulated velocity in the xy plane
 	// (don't count Z, or jumping messes it up)
 
-	bob = sqrt(cl.simvel[0]*cl.simvel[0] + cl.simvel[1]*cl.simvel[1]) * cl_bob.value;
+	bob = Q_sqrt(cl.simvel[0]*cl.simvel[0] + cl.simvel[1]*cl.simvel[1]) * cl_bob.value;
 	bob = bob*0.3 + bob*0.7*q_sinrad(cycle);
 	if (bob > 4)
 		bob = 4;
@@ -403,7 +403,7 @@ void V_ParseDamage (void)
 // calculate view angle kicks
 //
 	VectorSubtract (from, cl.simorg, from);
-	VectorNormalize (from);
+	VectorNormalizeFast (from);
 
 	AngleVectors (cl.simangles, forward, right, up);
 


### PR DESCRIPTION
This was originally intended to speed up the dynamic lights on alias models, but they ended up being useful at other places as well. The new inline functions in mathlib.h:
``Q_sqrt`` - based on https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Approximations_that_depend_on_the_floating_point_representation
``Q_rsqrt`` - fast inverse square root, like in Quake III
``VectorLengthFast`` - VectorLength using Q_sqrt
``VectorNormalizeFast`` - VectorNormalize using Q_rsqrt, and Q_sqrt when the return value is needed

They are pretty accurate, but I used these only sparingly in the GL version, mostly for the dynamic lights. In the software renderer I used them for most of the client-side effects.
