### PR TITLE
Added early return for SCR_DrawFPS

### DIFF
--- a/engine/h2shared/gl_screen.c
+++ b/engine/h2shared/gl_screen.c
@@ -536,6 +536,11 @@ static void SCR_DrawFPS (void)
 	static int	oldframecount = 0;
 	double	elapsed_time;
 	int	frames;
+	char	st[16];
+	int	x, y;
+
+	if (!scr_showfps.integer)
+		return;
 
 	elapsed_time = realtime - oldtime;
 	frames = r_framecount - oldframecount;
@@ -554,16 +559,11 @@ static void SCR_DrawFPS (void)
 		oldframecount = r_framecount;
 	}
 
-	if (scr_showfps.integer)
-	{
-		char	st[16];
-		int	x, y;
-		sprintf(st, "%4.0f FPS", lastfps);
-		x = vid.width - strlen(st) * 8 - 8;
-		y = vid.height - sb_lines - 8;
-	//	Draw_TileClear(x, y, strlen(st) * 8, 8);
-		Draw_String(x, y, st);
-	}
+	sprintf(st, "%4.0f FPS", lastfps);
+	x = vid.width - strlen(st) * 8 - 8;
+	y = vid.height - sb_lines - 8;
+//	Draw_TileClear(x, y, strlen(st) * 8, 8);
+	Draw_String(x, y, st);
 }
 
 /*

--- a/engine/h2shared/screen.c
+++ b/engine/h2shared/screen.c
@@ -567,6 +567,11 @@ static void SCR_DrawFPS (void)
 	static int	oldframecount = 0;
 	double	elapsed_time;
 	int	frames;
+	char	st[16];
+	int	x, y;
+
+	if (!scr_showfps.integer)
+		return;
 
 	elapsed_time = realtime - oldtime;
 	frames = r_framecount - oldframecount;
@@ -585,16 +590,11 @@ static void SCR_DrawFPS (void)
 		oldframecount = r_framecount;
 	}
 
-	if (scr_showfps.integer)
-	{
-		char	st[16];
-		int	x, y;
-		sprintf(st, "%4.0f FPS", lastfps);
-		x = vid.width - strlen(st) * 8 - 8;
-		y = vid.height - sb_lines - 8;
-	//	Draw_TileClear(x, y, strlen(st) * 8, 8);
-		Draw_String(x, y, st);
-	}
+	sprintf(st, "%4.0f FPS", lastfps);
+	x = vid.width - strlen(st) * 8 - 8;
+	y = vid.height - sb_lines - 8;
+//	Draw_TileClear(x, y, strlen(st) * 8, 8);
+	Draw_String(x, y, st);
 }
 
 /*


### PR DESCRIPTION
I modified SCR_DrawFPS to work like the other SCR_Draw* functions. Now it returns immediately if showfps is 0 instead of calculating the framerate unnecessarily.  