### PR TITLE
Commented out some dead code

### DIFF
--- a/engine/h2shared/d_edge.c
+++ b/engine/h2shared/d_edge.c
@@ -35,6 +35,7 @@ extern void	R_RotateBmodel (void);
 vec3_t		transformed_modelorg;
 
 
+#if 0
 /*
 ==============
 D_DrawPoly
@@ -45,6 +46,7 @@ void D_DrawPoly (void)
 {
 // this driver takes spans, not polygons
 }
+#endif
 
 
 /*

--- a/engine/h2shared/d_init.c
+++ b/engine/h2shared/d_init.c
@@ -49,8 +49,10 @@ void D_Init (void)
 	Cvar_RegisterVariable (&d_mipcap);
 	Cvar_RegisterVariable (&d_mipscale);
 
+#if 0
 	r_drawpolys = false;
 	r_worldpolysbacktofront = false;
+#endif
 	r_recursiveaffinetriangles = true;
 	r_pixbytes = 1;
 	r_aliasuvscale = 1.0;

--- a/engine/h2shared/r_bsp.c
+++ b/engine/h2shared/r_bsp.c
@@ -565,6 +565,7 @@ static void R_RecursiveWorldNode (mnode_t *node, int clipflags)
 					if ((surf->flags & SURF_PLANEBACK) &&
 						(surf->visframe == r_framecount))
 					{
+#if 0
 						if (r_drawpolys)
 						{
 							if (r_worldpolysbacktofront)
@@ -582,6 +583,7 @@ static void R_RecursiveWorldNode (mnode_t *node, int clipflags)
 							}
 						}
 						else
+#endif
 						{
 							R_RenderFace (surf, clipflags);
 						}
@@ -597,6 +599,7 @@ static void R_RecursiveWorldNode (mnode_t *node, int clipflags)
 					if (!(surf->flags & SURF_PLANEBACK) &&
 						(surf->visframe == r_framecount))
 					{
+#if 0
 						if (r_drawpolys)
 						{
 							if (r_worldpolysbacktofront)
@@ -614,6 +617,7 @@ static void R_RecursiveWorldNode (mnode_t *node, int clipflags)
 							}
 						}
 						else
+#endif
 						{
 							R_RenderFace (surf, clipflags);
 						}
@@ -653,6 +657,7 @@ void R_RenderWorld (void)
 
 	R_RecursiveWorldNode (clmodel->nodes, 15);
 
+#if 0
 // if the driver wants the polygons back to front,
 // play the visible ones back in that order
 	if (r_worldpolysbacktofront)
@@ -662,5 +667,6 @@ void R_RenderWorld (void)
 			R_RenderPoly (btofpolys[i].psurf, btofpolys[i].clipflags);
 		}
 	}
+#endif
 }
 

--- a/engine/h2shared/r_bsp.c
+++ b/engine/h2shared/r_bsp.c
@@ -644,7 +644,6 @@ R_RenderWorld
 */
 void R_RenderWorld (void)
 {
-	int			i;
 	qmodel_t	*clmodel;
 	btofpoly_t	btofpolys[MAX_BTOFPOLYS];
 
@@ -662,6 +661,7 @@ void R_RenderWorld (void)
 // play the visible ones back in that order
 	if (r_worldpolysbacktofront)
 	{
+		int	i;
 		for (i = numbtofpolys-1 ; i >= 0 ; i--)
 		{
 			R_RenderPoly (btofpolys[i].psurf, btofpolys[i].clipflags);

--- a/engine/h2shared/r_draw.c
+++ b/engine/h2shared/r_draw.c
@@ -691,6 +691,7 @@ void R_RenderBmodelFace (bedge_t *pedges, msurface_t *psurf)
 }
 
 
+#if 0
 /*
 ================
 R_RenderPoly
@@ -905,4 +906,5 @@ void R_ZDrawSubmodelPolys (qmodel_t *pmodel)
 		}
 	}
 }
+#endif
 

--- a/engine/h2shared/r_edge.c
+++ b/engine/h2shared/r_edge.c
@@ -80,6 +80,7 @@ static void R_LeadingEdgeBackwards (edge_t *edge);
 //=============================================================================
 
 
+#if 0
 /*
 ==============
 R_DrawCulledPolys
@@ -121,6 +122,7 @@ static void R_DrawCulledPolys (void)
 		}
 	}
 }
+#endif
 
 
 /*
@@ -1041,11 +1043,13 @@ void R_ScanEdges (qboolean Translucent)
 			S_ExtraUpdate ();	// don't let sound get messed up if going slow
 			VID_LockBuffer ();
 
+#if 0
 			if (r_drawculledpolys)
 			{
 				R_DrawCulledPolys ();
 			}
 			else
+#endif
 			{
 				D_DrawSurfaces (Translucent);
 			}
@@ -1084,9 +1088,11 @@ void R_ScanEdges (qboolean Translucent)
 		(*pdrawTfunc) ();
 
 	// draw whatever's left in the span list
+#if 0
 	if (r_drawculledpolys)
 		R_DrawCulledPolys ();
 	else
+#endif
 	{
 		D_DrawSurfaces (Translucent);
 	}

--- a/engine/h2shared/r_sky.c
+++ b/engine/h2shared/r_sky.c
@@ -157,6 +157,7 @@ void R_MakeSky (void)
 #endif /* !id68k */
 
 
+#if 0
 /*
 =================
 R_GenSkyTile
@@ -255,6 +256,7 @@ void R_GenSkyTile16 (void *pdest)
 		pnewsky += TILE_SIZE;
 	}
 }
+#endif
 
 
 /*

--- a/engine/h2shared/r_surf.c
+++ b/engine/h2shared/r_surf.c
@@ -607,6 +607,7 @@ static void R_DrawSurfaceBlock16 (void)
 
 //============================================================================
 
+#if 0
 /*
 ================
 R_GenTurbTile
@@ -695,4 +696,5 @@ void R_GenTile (msurface_t *psurf, void *pdest)
 		Sys_Error ("Unknown tile type");
 	}
 }
+#endif
 

--- a/engine/hexen2/r_main.c
+++ b/engine/hexen2/r_main.c
@@ -38,9 +38,11 @@ float		r_lasttime1 = 0;
 
 int		r_numallocatededges;
 
+#if 0
 qboolean	r_drawpolys;
 qboolean	r_drawculledpolys;
 qboolean	r_worldpolysbacktofront;
+#endif
 qboolean	r_recursiveaffinetriangles = true;
 
 int		r_pixbytes = 1;
@@ -1048,6 +1050,7 @@ static void R_DrawBEntitiesOnList (void)
 					}
 				}
 
+#if 0
 				// if the driver wants polygons, deliver those. Z-buffering is on
 				// at this point, so no clipping to the world tree is needed, just
 				// frustum clipping
@@ -1056,6 +1059,7 @@ static void R_DrawBEntitiesOnList (void)
 					R_ZDrawSubmodelPolys (clmodel);
 				}
 				else
+#endif
 				{
 					r_pefragtopnode = NULL;
 
@@ -1177,8 +1181,10 @@ static void R_EdgeDrawing (qboolean Translucent)
 		memcpy(surfaces,SaveSurfaces,SaveSurfacesCount * sizeof(surf_t));
 	}
 
+#if 0
 	if (r_drawculledpolys)
 		R_ScanEdges (Translucent);
+#endif
 
 // only the world can be drawn back to front with no z reads or compares, just
 // z writes, so have the driver turn z compares on now
@@ -1225,7 +1231,9 @@ static void R_EdgeDrawing (qboolean Translucent)
 		}
 	}
 
+#if 0
 	if (!(r_drawpolys | r_drawculledpolys))
+#endif
 		R_ScanEdges (Translucent);
 }
 

--- a/engine/hexen2/r_part.c
+++ b/engine/hexen2/r_part.c
@@ -242,6 +242,7 @@ void R_ReadPointFile_f (void)
 }
 
 
+#if 0	/* EF_BRIGHTFIELD used this */
 /*
 ===============
 R_EntityParticles
@@ -304,6 +305,7 @@ void R_EntityParticles (entity_t *ent)
 		p->org[2] = ent->origin[2] + r_avertexnormals[i][2]*dist + forward[2]*beamlength;
 	}
 }
+#endif
 
 
 /*

--- a/engine/hexenworld/client/r_main.c
+++ b/engine/hexenworld/client/r_main.c
@@ -38,9 +38,11 @@ float		r_lasttime1 = 0;
 
 int		r_numallocatededges;
 
+#if 0
 qboolean	r_drawpolys;
 qboolean	r_drawculledpolys;
 qboolean	r_worldpolysbacktofront;
+#endif
 qboolean	r_recursiveaffinetriangles = true;
 
 int		r_pixbytes = 1;
@@ -1077,6 +1079,7 @@ static void R_DrawBEntitiesOnList (void)
 					}
 				}
 
+#if 0
 				// if the driver wants polygons, deliver those. Z-buffering is on
 				// at this point, so no clipping to the world tree is needed, just
 				// frustum clipping
@@ -1085,6 +1088,7 @@ static void R_DrawBEntitiesOnList (void)
 					R_ZDrawSubmodelPolys (clmodel);
 				}
 				else
+#endif
 				{
 					r_pefragtopnode = NULL;
 
@@ -1206,8 +1210,10 @@ static void R_EdgeDrawing (qboolean Translucent)
 		memcpy(surfaces,SaveSurfaces,SaveSurfacesCount * sizeof(surf_t));
 	}
 
+#if 0
 	if (r_drawculledpolys)
 		R_ScanEdges (Translucent);
+#endif
 
 // only the world can be drawn back to front with no z reads or compares, just
 // z writes, so have the driver turn z compares on now
@@ -1255,7 +1261,9 @@ static void R_EdgeDrawing (qboolean Translucent)
 		}
 	}
 
+#if 0
 	if (!(r_drawpolys | r_drawculledpolys))
+#endif
 		R_ScanEdges (Translucent);
 }
 

--- a/engine/hexenworld/client/r_part.c
+++ b/engine/hexenworld/client/r_part.c
@@ -229,6 +229,7 @@ void R_ReadPointFile_f (void)
 }
 
 
+#if 0	/* EF_BRIGHTFIELD used this */
 /*
 ===============
 R_EntityParticles
@@ -291,6 +292,7 @@ void R_EntityParticles (entity_t *ent)
 		p->org[2] = ent->origin[2] + r_avertexnormals[i][2]*dist + forward[2]*beamlength;
 	}
 }
+#endif
 
 void R_SuccubusInvincibleParticles (entity_t *ent)
 {


### PR DESCRIPTION
There was a good amount of dead code, mostly remnants of the software polygon renderer (maybe used by vQuake?), and the old particle effect for EF_BRIGHTFIELD. This gets rid of many unnecessary conditions and reduces the executable size a bit.