### PR TITLE
Add freedesktop metadata

### DIFF
--- a/engine/resource/net.sourceforge.uhexen2.uhexen2.appdata.xml
+++ b/engine/resource/net.sourceforge.uhexen2.uhexen2.appdata.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<application>
+  <id type="desktop">net.sourceforge.uhexen2.uhexen2</id>
+  <name>Hexen II: Hammer of Thyrion</name>
+  <developer_name>uHexen2 Contributors</developer_name>
+  <summary>A modernized source port of Hexen II.</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0-only</project_license>
+  <url type="homepage">https://uhexen2.sourceforge.net/</url>
+  <description>
+    <p> In 2000, Raven Software released the source code to their class based shooter game Hexen II and its multiplayer extension
+        HexenWorld. Since then, there has been some source ports of this game, such as the now discontinued Anvil of Thyrion project,
+        but nothing has been done for Linux since the beginning of 2002.</p>
+    <p>The Hammer of Thyrion project is a cross-platform source port effort: We continue the development for Linux, BSD and Mac OS X people,
+        with continued support for Windows users as well. Many bugs are fixed and even new features are added: New sound modes, improved
+        mouse handling, improved video modes, OpenGL glows and more. You can go to our project page for more information.</p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://a.fsdn.com/con/app/proj/uhexen2/screenshots/320847.jpg/max/max/1</image>
+      <caption>Cathedral</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://a.fsdn.com/con/app/proj/uhexen2/screenshots/9153.jpg/max/max/1</image>
+      <caption>Chase Mode</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://a.fsdn.com/con/app/proj/uhexen2/screenshots/320817.jpg/max/max/1</image>
+      <caption>FOV 105 (wide)</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://a.fsdn.com/con/app/proj/uhexen2/screenshots/01.png/max/max/1</image>
+      <caption>Baron Gastone House by Rino</caption>
+    </screenshot>
+    <screenshot>
+      <image type="source">https://a.fsdn.com/con/app/proj/uhexen2/screenshots/284891.jpg/max/max/1</image>
+      <caption>Colored lights</caption>
+    </screenshot>
+  </screenshots>
+  <categories>
+    <category>Game</category>
+  </categories>
+  <releases>
+    <release version="1.5.9" date="2018-06-06"/>
+  </releases>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+    <content_attribute id="violence-desecration">moderate</content_attribute>
+  </content_rating>
+  <update_contact>https://github.com/sezero/uhexen2/issues</update_contact>
+</application>

--- a/engine/resource/net.sourceforge.uhexen2.uhexen2.desktop
+++ b/engine/resource/net.sourceforge.uhexen2.uhexen2.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Hexen II: Hammer of Thyrion
+Comment=A modern Linux port of Hexen II
+Exec=glhexen2
+Icon=net.sourceforge.uhexen2.uhexen2
+StartupNotify=true
+PrefersNonDefaultGPU=true
+Terminal=false
+Type=Application
+Categories=Game;Shooter;
+Keywords=hexen;first;person;shooter;


### PR DESCRIPTION
As part of my [PR to FlatHub](https://github.com/flathub/flathub/pull/4541) for a Flatpak distribution, they suggested I submit .desktop launcher file and .appdata.xml file upstream. These are metadata files about the project in standardised formats used for a range of different applications across every modern Linux desktop environment.

As far as the icon specified in the .desktop file goes; as there isn't currently a standard distribution for uhexen2 this can be any arbitrary image - for the Flatpak build I'm bundling `engine/resources/hexen2n.png` for this as it's a 128x128 icon already included in the source repo.